### PR TITLE
Plaintext Regex Label aktualisiert

### DIFF
--- a/plugins/plaintext/lang/de_de.lang
+++ b/plugins/plaintext/lang/de_de.lang
@@ -5,7 +5,7 @@ search_it_plaintext_description = Elemente mit diesem Symbol können per Drag & 
 search_it_plaintext_selectors = CSS-Selektoren (komma-separiert)
 search_it_plaintext_selectors_label = Alle Elemente, auf die die Selektoren passen, werden aus dem Plaintext entfernt.
 search_it_plaintext_regex = Reguläre Ausdrücke (zeilenweise getrennt)
-search_it_plaintext_regex_label = Jede 1. Zeile: Regex<br />Jede 2. Zeile: Ersetzung<br /><a href="http://php.net/preg_replace">preg_replace()</a><br /><br />Beispiel:<br />~\s+~ism<br /> <em>(Leerzeichen)</em>
+search_it_plaintext_regex_label = Jede 1. Zeile: Regex<br />Jede 2. Zeile: Ersetzung<br /><a href="http://php.net/preg_replace">preg_replace()</a><br /><br />Beispiel:<br /><code>'<h1>.+</h1>'</code><br /><code>' '</code>
 search_it_plaintext_striptags = HTML-Tags entfernen
 search_it_plaintext_striptags_label = Wendet die Funktion strip_tags() auf den Plaintext an.
 search_it_plaintext_textile = Textile parsen

--- a/plugins/plaintext/lang/en_gb.lang
+++ b/plugins/plaintext/lang/en_gb.lang
@@ -5,7 +5,7 @@ search_it_plaintext_description = Elements marked with this symbol can be shifte
 search_it_plaintext_selectors = CSS-selectors (comma-separated)
 search_it_plaintext_selectors_label = All matching elements will be removed from plaintext.
 search_it_plaintext_regex = Regular Expressions (row-separated)
-search_it_plaintext_regex_label = Every 1. Line: Regex<br />Every 2. Line: Replacement<br /><a href="http://php.net/preg_replace">preg_replace()</a><br /><br />Example:<br />~\s+~ism<br /> <em>(space)</em>
+search_it_plaintext_regex_label = Every 1. Line: Regex<br />Every 2. Line: Replacement<br /><a href="http://php.net/preg_replace">preg_replace()</a><br /><br />Example:<br /><code>'<h1>.+</h1>'</code><br /><code>' '</code>
 search_it_plaintext_striptags = Remove HTML-tags
 search_it_plaintext_striptags_label = Executes the strip_tags()-function.
 search_it_plaintext_textile = parse with textile


### PR DESCRIPTION
Wenn die Zeilen ohne Anführungszeichen eingegeben werden, kommt bei der Erstellung des Index ein Fehler:

Warning: preg_replace(): Delimiter must not be alphanumeric or backslash in /kunden/redaxo/src/addons/search_it/plugins/plaintext/functions/functions_plaintext.php on line 42

Alternativ sollten die jeweiligen Such/Ersetzungsmuster direkt von search_it umschlossen werden. Dann aber bitte den Patch ohne Anführungszeichen trotzdem mergen, weil das Beispiel mit `<code>` umschlossen wurde.