### PR TITLE
Page permissions für Plugins

### DIFF
--- a/plugins/documentation/package.yml
+++ b/plugins/documentation/package.yml
@@ -6,6 +6,7 @@ title: 'translate:search_it_documentation_title'
 description: 'translate:search_it_documentation_title'
 
 page:
+    perm: search_it[plugin:documentation]
     title: 'translate:search_it_documentation_title'
     pjax: false
     icon: rex-icon fa-book

--- a/plugins/plaintext/package.yml
+++ b/plugins/plaintext/package.yml
@@ -6,5 +6,6 @@ title: 'translate:search_it_plaintext_title'
 description: 'translate:search_it_plaintext_title'
 
 page:
+    perm: search_it[plugin:plaintext]
     title: 'translate:search_it_plaintext_title'
     icon: rex-icon fa-file-text-o

--- a/plugins/stats/package.yml
+++ b/plugins/stats/package.yml
@@ -6,6 +6,7 @@ title: 'translate:search_it_stats_plugin_title'
 description: 'translate:search_it_stats_plugin'
 
 page:
+    perm: search_it[plugin:stats]
     title: 'translate:search_it_stats_plugin_title'
     icon: rex-icon fa-bar-chart
 


### PR DESCRIPTION
Mit den zusätzlichen Permissions lassen sich die Plugin-Seiten für einzelne Rollen ein- und ausblenden