### PR TITLE
Fixed „non-numeric value encountered“ warning

### DIFF
--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -132,7 +132,7 @@ class search_it
         $global_return = 0;
         $art_sql = rex_sql::factory();
         $art_sql->setTable($this->tablePrefix . 'article');
-        if ($art_sql->select('id,clang_id')) 
+        if ($art_sql->select('id,clang_id')) {
             foreach ($art_sql->getArray() as $art) {
                 $returns = $this->indexArticle($art['id'], $art['clang_id']);
                 foreach ( $returns as $return ) {

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -129,10 +129,10 @@ class search_it
 
 
         // index articles
-        $global_return = '';
+        $global_return = 0;
         $art_sql = rex_sql::factory();
         $art_sql->setTable($this->tablePrefix . 'article');
-        if ($art_sql->select('id,clang_id')) {
+        if ($art_sql->select('id,clang_id')) 
             foreach ($art_sql->getArray() as $art) {
                 $returns = $this->indexArticle($art['id'], $art['clang_id']);
                 foreach ( $returns as $return ) {


### PR DESCRIPTION
Gemeldet im slack

> Moin :slightly_smiling_face:
Will grad search_it aufm neuen Webserver installieren. Beim erstellen des Index kommen folgende Fehler:
`Warning: A non-numeric value encountered in redaxo/src/addons/search_it/lib/search_it.php on line 139`
und `Fehler bei der Indexierung`.
Im Log gibts dann die Nachricht: `Socket-Fehler bei der Indexierung per HTTP-GET von http://DIEDOMAIN.DE/suche/_suche_r?search_it_build_index=do+it%2C+baby<br>Undefined variable: errno`
Woran liegts?

Vermutlich ist dies der fix für die warning in php 7.1+, Ungetestet.
Ob es die ursache für das problem fixed, weiß ich nicht