### PR TITLE
Indexerstellung unter PHP 7.3

### DIFF
--- a/plugins/plaintext/lib/simple_html_dom.php
+++ b/plugins/plaintext/lib/simple_html_dom.php
@@ -766,7 +766,7 @@ class simple_html_dom {
             return true;
         }
 
-        if (!preg_match("/^[\w-:]+$/", $tag)) {
+        if (!preg_match("/^[\w\-:]+$/", $tag)) {
             $node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
             if ($this->char==='<') {
                 $this->link_nodes($node, false);


### PR DESCRIPTION
Getestet mit PHP Versionen 7.0 und 7.3. Der Index wird dann ohne Fehlermeldung erstellt.

#197 