### PR TITLE
Release 6.6.6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Änderungen von search_it
+## Version 6.6.6 (2019-08-14)
 - Verbesserte, übersetzte Fehlermeldungen, korrekte Verwendung des jeweiligen Protokolls bei Weiterleitungen
 - FIX: DB Suchindex unvollständig bei schrittweiser Indexierung #208 thx @dtpop
 - Fix EP CAT_STATUS deindexiert nicht Kategorie-Startartikel #202 thx @alexwenz

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '6.6.5'
+version: '6.6.6'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 

--- a/plugins/autocomplete/package.yml
+++ b/plugins/autocomplete/package.yml
@@ -1,5 +1,5 @@
 package: search_it/autocomplete
-version: '6.6.5'
+version: '6.6.6'
 author: Manétage
 
 title: 'translate:search_it_autocomplete_plugin_title'

--- a/plugins/documentation/package.yml
+++ b/plugins/documentation/package.yml
@@ -1,5 +1,5 @@
 package: search_it/documentation
-version: '6.6.5'
+version: '6.6.6'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_documentation_title'

--- a/plugins/plaintext/package.yml
+++ b/plugins/plaintext/package.yml
@@ -1,5 +1,5 @@
 package: search_it/plaintext
-version: '6.6.5'
+version: '6.6.6'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_plaintext_title'

--- a/plugins/stats/package.yml
+++ b/plugins/stats/package.yml
@@ -1,5 +1,5 @@
 package: search_it/stats
-version: '6.6.5'
+version: '6.6.6'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_stats_plugin_title'


### PR DESCRIPTION
- Verbesserte, übersetzte Fehlermeldungen, korrekte Verwendung des jeweiligen Protokolls bei Weiterleitungen
- FIX: DB Suchindex unvollständig bei schrittweiser Indexierung #208 thx @dtpop
- Fix EP CAT_STATUS deindexiert nicht Kategorie-Startartikel #202 thx @alexwenz
- Fixed "non-numeric value encountered" warning #198 thx @staabm