### PR TITLE
autocomplete: keine Voreinstellung für 'similarwordsmode'

### DIFF
--- a/plugins/autocomplete/boot.php
+++ b/plugins/autocomplete/boot.php
@@ -12,6 +12,7 @@
             $this->setConfig(array(
                 'modus' => 'keywords',
                 'maxSuggestion' => '10',
+                'similarwordsmode' => '0',
                 'autoSubmitForm' => 1
             ));
         }


### PR DESCRIPTION
 closes #219

erzeugte leere Query ->whoops oder 500er