### PR TITLE
preg_split as array

### DIFF
--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -357,7 +357,7 @@ class search_it
                     $articleData['values'] = serialize($additionalValues);
                 }
 
-                foreach (preg_split('~[[:punct:][:space:]]+~ismu', $plaintext) as $keyword) {
+                foreach ((array) preg_split('~[[:punct:][:space:]]+~ismu', $plaintext) as $keyword) {
                     if ($this->significantCharacterCount <= mb_strlen($keyword, 'UTF-8')) {
                         $keywords[] = array('search' => $keyword, 'clang' => $langID);
                     }
@@ -1093,7 +1093,7 @@ class search_it
     private function getTeaserText($_text)
     {
         $i = 0;
-        $textArray = preg_split('~\s+~siu', $_text, $this->maxTeaserChars);
+        $textArray = (array) preg_split('~\s+~siu', $_text, $this->maxTeaserChars);
 
         $return = '';
         $aborted = false;


### PR DESCRIPTION
preg_split liefert auch mal was anderes als ein array. Um Warnings zu verhindern, wird gecastet