### PR TITLE
Release 6.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
-# Änderungen von search_it
-- update.php now includes install.php
+## Versione 6.7.3 (2020-10-13)
+- update.php now includes install.php @skerbis
 - Add index on column "hash" in table rex_tmp_search_it_cache @xong
 - Fix syslog error messages
 - avoid cascading indexing (#291), Performanceupdate für URL Addon URLs (#277), autoupdate urls from url addon 2.x (#289) thx  @TobiasKrais
 - Escape term output to redeem xss-vulnerability (#290) thx @DanielWeitenauer
 - change member variables $tablePrefix and $tempTablePrefix as static functions thx @elricco, @xong
 - markdown fixes thx @alexplus, @danspringer
-
-## Versione 6.7.3 (2020-10-13
-- Added index to hash column for better performance 
-- Some minor changes to update.php
 
 ## Version 6.7.2 (2020-05-05)
 - Fix stats plugin 2

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '6.7.2'
+version: '6.7.3'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 

--- a/plugins/autocomplete/package.yml
+++ b/plugins/autocomplete/package.yml
@@ -1,5 +1,5 @@
 package: search_it/autocomplete
-version: '6.7.2'
+version: '6.7.3'
 author: Manétage
 
 title: 'translate:search_it_autocomplete_plugin_title'

--- a/plugins/documentation/package.yml
+++ b/plugins/documentation/package.yml
@@ -1,5 +1,5 @@
 package: search_it/documentation
-version: '6.7.2'
+version: '6.7.3'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_documentation_title'

--- a/plugins/plaintext/package.yml
+++ b/plugins/plaintext/package.yml
@@ -1,5 +1,5 @@
 package: search_it/plaintext
-version: '6.7.2'
+version: '6.7.3'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_plaintext_title'

--- a/plugins/stats/package.yml
+++ b/plugins/stats/package.yml
@@ -1,5 +1,5 @@
 package: search_it/stats
-version: '6.7.2'
+version: '6.7.3'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_stats_plugin_title'


### PR DESCRIPTION
- update.php now includes install.php
- Add index on column "hash" in table rex_tmp_search_it_cache
- Fix syslog error messages
- avoid cascading indexing (#291), Performanceupdate für URL Addon URLs (#277), autoupdate urls from url addon 2.x (#289) 
- Escape term output to redeem xss-vulnerability (#290) 
- change member variables $tablePrefix and $tempTablePrefix as static functions 
- markdown fixes 