### PR TITLE
Soundex nicht bei Zahlen verwenden - fix #300

### DIFF
--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2134,7 +2134,7 @@ class search_it
             $simwordQuerys = [];
             foreach ($this->searchArray as $keyword) {
                 $sounds = [];
-                if ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_SOUNDEX) {
+                if ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_SOUNDEX && !is_numeric(soundex($keyword['search']))) {
                     $sounds[] = "soundex = '" . soundex($keyword['search']) . "'";
                 }
 
@@ -2145,20 +2145,22 @@ class search_it
                 if ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_COLOGNEPHONE) {
                     $sounds[] = "colognephone = '" . soundex_ger($keyword['search']) . "'";
                 }
-                $simwordQuerys[] = sprintf("
-                  (SELECT
-                    GROUP_CONCAT(DISTINCT keyword SEPARATOR ' ') as keyword,
-                    %s AS typedin,
-                    SUM(count) as count
-                  FROM `%s`
-                  WHERE 1
-                    %s
-                    AND (%s))",
-                    $simWordsSQL->escape($keyword['search']),
-                    self::getTempTablePrefix() . 'search_it_keywords',
-                    ($this->clang !== false) ? 'AND (clang = ' . intval($this->clang) . ' OR clang IS NULL)' : '',
-                    implode(' OR ', $sounds)
-                );
+                if(count($sounds) > 0) {
+					$simwordQuerys[] = sprintf("
+					  (SELECT
+						GROUP_CONCAT(DISTINCT keyword SEPARATOR ' ') as keyword,
+						%s AS typedin,
+						SUM(count) as count
+					  FROM `%s`
+					  WHERE 1
+						%s
+						AND (%s))",
+						$simWordsSQL->escape($keyword['search']),
+						self::getTempTablePrefix() . 'search_it_keywords',
+						($this->clang !== false) ? 'AND (clang = ' . intval($this->clang) . ' OR clang IS NULL)' : '',
+						implode(' OR ', $sounds)
+					);
+				}
             }
             //echo '<br><pre>'; var_dump($simwordQuerys);echo '</pre>'; // Eine SQL-Abfrage pro Suchwort
 

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2165,43 +2165,45 @@ class search_it
             //echo '<br><pre>'; var_dump($simwordQuerys);echo '</pre>'; // Eine SQL-Abfrage pro Suchwort
 
             // simwords
-            $simWordsSQL = rex_sql::factory();
-            foreach ($simWordsSQL->getArray(sprintf("
-                SELECT * FROM (%s) AS t
-                %s
-                ORDER BY count",
-                    implode(' UNION ', $simwordQuerys),
-                    $this->similarwordsPermanent ? '' : 'GROUP BY keyword, typedin'
-                )
-            ) as $simword) {
-                //echo '<br><pre>'; var_dump($simword);echo '</pre>';
-                $return['simwords'][$simword['typedin']] = array(
-                    'keyword' => $simword['keyword'],
-                    'typedin' => $simword['typedin'],
-                    'count' => $simword['count'],
-                );
-            }
-            /*echo '<br><pre>' .sprintf("
-            SELECT * FROM (%s) AS t
-            %s
-            ORDER BY count",
-                implode(' UNION ', $simwordQuerys),
-                $this->similarwordsPermanent ? '' : 'GROUP BY keyword, typedin'
-            ).'</pre>'; die();*/
-            $newsearch = [];
-            foreach ($this->searchArray as $keyword) {
-                if (preg_match('~\s~isu', $keyword['search'])) {
-                    $quotes = '"';
-                } else {
-                    $quotes = '';
-                }
+			if(count($simwordQuerys) > 0) {
+				$simWordsSQL = rex_sql::factory();
+				foreach ($simWordsSQL->getArray(sprintf("
+					SELECT * FROM (%s) AS t
+					%s
+					ORDER BY count",
+						implode(' UNION ', $simwordQuerys),
+						$this->similarwordsPermanent ? '' : 'GROUP BY keyword, typedin'
+					)
+				) as $simword) {
+					//echo '<br><pre>'; var_dump($simword);echo '</pre>';
+					$return['simwords'][$simword['typedin']] = array(
+						'keyword' => $simword['keyword'],
+						'typedin' => $simword['typedin'],
+						'count' => $simword['count'],
+					);
+				}
+				/*echo '<br><pre>' .sprintf("
+				SELECT * FROM (%s) AS t
+				%s
+				ORDER BY count",
+					implode(' UNION ', $simwordQuerys),
+					$this->similarwordsPermanent ? '' : 'GROUP BY keyword, typedin'
+				).'</pre>'; die();*/
+				$newsearch = [];
+				foreach ($this->searchArray as $keyword) {
+					if (preg_match('~\s~isu', $keyword['search'])) {
+						$quotes = '"';
+					} else {
+						$quotes = '';
+					}
 
-                if (array_key_exists($keyword['search'], $return['simwords'])) {
-                    $newsearch[] = $quotes . $return['simwords'][$keyword['search']]['keyword'] . $quotes;
-                } else {
-                    $newsearch[] = $quotes . $keyword['search'] . $quotes;
-                }
-            }
+					if (array_key_exists($keyword['search'], $return['simwords'])) {
+						$newsearch[] = $quotes . $return['simwords'][$keyword['search']]['keyword'] . $quotes;
+					} else {
+						$newsearch[] = $quotes . $keyword['search'] . $quotes;
+					}
+				}
+			}
 
             $return['simwordsnewsearch'] = implode(' ', $newsearch);
         }
@@ -2280,7 +2282,7 @@ class search_it
         $match = '(' . implode(' + ', $Amatch) . ' + 1)';
 
         // build WHERE-String
-        $where = '(' . implode($this->logicalMode, $A2Where) . ')';
+        $where = count($A2Where) > 0 ? '(' . implode($this->logicalMode, $A2Where) . ')' : '1';
         //$where = sprintf("( MATCH (%s) AGAINST ('%s' IN BOOLEAN MODE)) > 0",implode(',',$searchColumns),implode(' ',$Awhere));
 
         // language

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2049,7 +2049,7 @@ class search_it
                 $simWords[] = sprintf(
                     "(%s, '%s', '%s', '%s', %s)",
                     $simWordsSQL->escape($keyword['search']),
-                    ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_SOUNDEX) ? soundex($keyword['search']) : '',
+                    ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_SOUNDEX && !is_numeric(soundex($keyword['search']))) ? soundex($keyword['search']) : '',
                     ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_METAPHONE) ? metaphone($keyword['search']) : '',
                     ($this->similarwordsMode & SEARCH_IT_SIMILARWORDS_COLOGNEPHONE) ? soundex_ger($keyword['search']) : '',
                     (isset($keyword['clang']) AND $keyword['clang'] !== false) ? $keyword['clang'] : '-1'


### PR DESCRIPTION
Soundex darf nicht bei Zahlen verwendet werden. Der PR schränkt die Verwendung entsprechend ein.