### PR TITLE
Ähnlichkeitssuche Doku verbessert

### DIFF
--- a/plugins/documentation/docs/de_de/module-simsearch.md
+++ b/plugins/documentation/docs/de_de/module-simsearch.md
@@ -15,25 +15,15 @@ Sollte eine Suche keine Ergebnisse liefern, füllt Search it das Result-Array mi
 ```php
 <?php
 $request = rex_request('search', 'string', false);
+$article = rex_article::getCurrent();
+$sim_limit = 10; // Maximales Limit ähnlicher Suchbegriffe
 
 if($request) { // Wenn ein Suchbegriff eingegeben wurde
     $server = rtrim(rex::getServer(), "/");
 
-    print '<section class="search_it-hits">';
-
-    // Init search and execute
+    // Suche wie initieren und ausführen
     $search_it = new search_it();
     $result = $search_it->search($request);
-
-    echo '<h2 class="search_it-headline">Suchergebnisse</h2>';
-    if($result['count'] == 0 && count($result['simwords']) > 0){
-        // Ähnlichkeitssuche ausgeben
-        $newsearchString = $result['simwordsnewsearch'];
-        $result_simwords = $search_it->search($newsearchString);
-        if($result_simwords['count'] > 0){
-            echo '<p>Meinten Sie <strong>'. $newsearchString .'</strong>?</p>';
-        }
-    }
 
     if($result['count']) {
         // Ausgabe der Treffer
@@ -41,6 +31,27 @@ if($request) { // Wenn ein Suchbegriff eingegeben wurde
     else if(!$result['count']) {
         echo '<p class="search_it-zero">{{ d2u_helper_module_14_search_results_none }}</p>';
     }
-    print "</section>";
+    
+    if(!$result['count'] && !empty($result['simwordsnewsearch'])){
+        // Ähnlichkeitssuche ausgeben
+    	$search_it->setLimit(0, 1); // um zu prüfen, ob für einen ähnlichen Begriff ein Ergebnis vorhanden ist, brauchst es nur einen Treffer
+		$simwords_out = '<p>Folgende ähnliche Suchbegriffe mit Treffern wurden gefunden:<strong><ul>';
+		$sim_counter = 0;
+		foreach (explode(' ', trim($result['simwordsnewsearch'])) as $new_search_word) {
+			$result_simwords = $search_it->search(trim($new_search_word));
+			if($result_simwords['count'] > 0) {
+				$simwords_out .= '<li><a href="'. $article->getUrl(['search' => $new_search_word]) .'">'. $new_search_word .'</a></li>';
+				$sim_counter++;
+                // Optional: Anzahl ähnlicher Suchbegriffe begrenzen
+				if($sim_counter >= $sim_limit) {
+					break;
+				}
+			}
+		}
+		$simwords_out .= '</ul></strong></p>';
+		if($sim_counter > 0) {
+			print $simwords_out;
+		}
+    }
 }
 ```

--- a/plugins/documentation/docs/de_de/module-simsearch.md
+++ b/plugins/documentation/docs/de_de/module-simsearch.md
@@ -42,7 +42,7 @@ if($request) { // Wenn ein Suchbegriff eingegeben wurde
 			if($result_simwords['count'] > 0) {
 				$simwords_out .= '<li><a href="'. $article->getUrl(['search' => $new_search_word]) .'">'. $new_search_word .'</a></li>';
 				$sim_counter++;
-                // Optional: Anzahl ähnlicher Suchbegriffe begrenzen
+				// Optional: Anzahl ähnlicher Suchbegriffe begrenzen
 				if($sim_counter >= $sim_limit) {
 					break;
 				}
@@ -50,7 +50,7 @@ if($request) { // Wenn ein Suchbegriff eingegeben wurde
 		}
 		$simwords_out .= '</ul></strong></p>';
 		if($sim_counter > 0) {
-			print $simwords_out;
+			echo $simwords_out;
 		}
     }
 }

--- a/plugins/documentation/docs/de_de/module-simsearch.md
+++ b/plugins/documentation/docs/de_de/module-simsearch.md
@@ -29,7 +29,7 @@ if($request) { // Wenn ein Suchbegriff eingegeben wurde
         // Ausgabe der Treffer
     }
     else if(!$result['count']) {
-        echo '<p class="search_it-zero">{{ d2u_helper_module_14_search_results_none }}</p>';
+        echo '<p class="search_it-zero">Es wurden keine Suchergebnisse gefunden.</p>';
     }
     
     if(!$result['count'] && !empty($result['simwordsnewsearch'])){


### PR DESCRIPTION
Das ehemalige Codebeispiel hat in einigen Fällen hunderte ähnliche Begriffe geliefert und dann eine Suche gestartet. Dabei waren alle Begriffe verkettet und konnten einen Fatal Error auslösen, wenn die Zeichenkette zu lang war. Siehe https://github.com/FriendsOfREDAXO/search_it/issues/300.