### PR TITLE
Doku-Plugin CSS-Ausgabe im Backend

### DIFF
--- a/plugins/documentation/boot.php
+++ b/plugins/documentation/boot.php
@@ -1,5 +1,5 @@
 <?php
 
-if (rex::isBackend() && rex::getUser()) {
+if (rex::isBackend() && rex::getUser() && 'search_it' == rex_be_controller::getCurrentPagePart(1)) {
     rex_view::addCssFile($this->getAssetsUrl('docs.css'));
 }


### PR DESCRIPTION
CSS für Doku-Plugin im Backend nur auf der search_it-Seite ausgeben