### PR TITLE
übergäbe der cron class per ::class

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -45,7 +45,7 @@ if ( rex_addon::get('search_it')->getConfig('reindex_cols_onforms') == true ) {
 	rex_extension::register('REX_FORM_DELETED', 'search_it_reindex_cols');
 }
 if ( rex_addon::get('cronjob')->isAvailable() && !rex::isSafeMode() ) {
-	rex_cronjob_manager::registerType('rex_cronjob_reindex');
+	rex_cronjob_manager::registerType(rex_cronjob_reindex::class);
 }
 
 if ( rex_request('search_it_build_index','string','') != '' ) {


### PR DESCRIPTION
psalm sieht das gerne so um sicher zu stellen dass es als String übergeben wird.