### PR TITLE
Version 6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-## Versione 6.9.0 (2021-12-18)
+## Version 6.9.0 (2021-12-18)
 - NEU: host & port kann für den Indexierungsvorgang angegeben werden
 - NEU ab REDAXO 5.13: Die Verifizierung des SSL-Zertifikat kann abgeschaltet werden (für lokale Entwicklung & selbst-ausgestellte Zertifikate)
 
-## Versione 6.8.1 (2021-11-16)
+## Version 6.8.1 (2021-11-16)
 - Fix für REDAXO 5.13
 
-## Versione 6.8.0 (2021-11-15)
+## Version 6.8.0 (2021-11-15)
 - console command search_it:reindex 
 - dark mode thx @schuer
 - diverse Fixes, Warnungen, Verbesserungen @aeberhard, @TobiasKrais, @skerbis, @marcohanke
 
-## Versione 6.7.3 (2020-10-13)
+## Version 6.7.3 (2020-10-13)
 - update.php now includes install.php @skerbis
 - Add index on column "hash" in table rex_tmp_search_it_cache @xong
 - Fix syslog error messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Versione 6.9.0 (2021-12-18)
 - NEU: host & port kann für den Indexierungsvorgang angegeben werden
-- NEU: SSL Verifizierung kann abgeschaltet werden (für lokale Entwicklung & selbst-ausgestellte Zertifikate)
+- NEU ab REDAXO 5.13: Die Verifizierung des SSL-Zertifikat kann abgeschaltet werden (für lokale Entwicklung & selbst-ausgestellte Zertifikate)
 
 ## Versione 6.8.1 (2021-11-16)
 - Fix für REDAXO 5.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Versione 6.9.0 (2021-12-18)
+- NEU: host & port kann für den Indexierungsvorgang angegeben werden
+- NEU: SSL Verifizierung kann abgeschaltet werden (für lokale Entwicklung & selbst-ausgestellte Zertifikate)
+
 ## Versione 6.8.1 (2021-11-16)
 - Fix für REDAXO 5.13
 

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -28,10 +28,10 @@ search_it_settings_indexoffline = Offline-Artikel indexieren
 search_it_settings_automaticindex_label = Artikel (ADD, EDIT, DELETE) automatisch (de)indexieren
 search_it_settings_reindex_cols_onforms_label = Reindexieren aller Spalten, wenn Tabellen mit YForm oder form bearbeitet werden
 search_it_settings_index_url_addon_label = URLs aus dem URL Addon (Version >=2) indexieren
-search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen ( hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
-search_it_settings_index_host_label = Soll über einen besonderen Host[:Port] indexiert werden? ( Bitte nur angeben, wenn unbedingt erforderlich )
+search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen (hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten)
+search_it_settings_index_host_label = Soll über einen besonderen Host[:Port] indexiert werden? (Bitte nur angeben, wenn unbedingt erforderlich)
 
-search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess Passwortschutz)
+search_it_settings_http_authbasic = HTTP Basic AUTH (.htaccess Passwortschutz)
 search_it_settings_http_auth_desc = Wenn ein Zugriffsschutz die Website schützt, kann hier ein Login hinterlegt werden, um die Indexierung zu ermöglichen
 search_it_settings_htaccess_user = Username
 search_it_settings_htaccess_pass = Passwort

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -28,6 +28,8 @@ search_it_settings_indexoffline = Offline-Artikel indexieren
 search_it_settings_automaticindex_label = Artikel (ADD, EDIT, DELETE) automatisch (de)indexieren
 search_it_settings_reindex_cols_onforms_label = Reindexieren aller Spalten, wenn Tabellen mit YForm oder form bearbeitet werden
 search_it_settings_index_url_addon_label = URLs aus dem URL Addon (Version >=2) indexieren
+search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen ( hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
+search_it_settings_index_host_label = Host[:Port] über den Indexiert wird
 
 search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess Passwortschutz)
 search_it_settings_http_auth_desc = Wenn ein Zugriffsschutz die Website schützt, kann hier ein Login hinterlegt werden, um die Indexierung zu ermöglichen

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -29,7 +29,7 @@ search_it_settings_automaticindex_label = Artikel (ADD, EDIT, DELETE) automatisc
 search_it_settings_reindex_cols_onforms_label = Reindexieren aller Spalten, wenn Tabellen mit YForm oder form bearbeitet werden
 search_it_settings_index_url_addon_label = URLs aus dem URL Addon (Version >=2) indexieren
 search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen ( hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
-search_it_settings_index_host_label = Host[:Port] über den Indexiert wird
+search_it_settings_index_host_label = Soll über einen besonderen Host[:Port] indexiert werden? ( Bitte nur angeben, wenn unbedingt erforderlich )
 
 search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess Passwortschutz)
 search_it_settings_http_auth_desc = Wenn ein Zugriffsschutz die Website schützt, kann hier ein Login hinterlegt werden, um die Indexierung zu ermöglichen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -28,6 +28,8 @@ search_it_settings_indexoffline = Index offline articles
 search_it_settings_automaticindex_label = Index and deindex articles automatically (ADD, EDIT, DELETE)
 search_it_settings_reindex_cols_onforms_label = Reindex all columns, if tables are changed through YForm or form
 search_it_settings_index_url_addon_label = Index URL addon (version >=2) URLs
+search_it_settings_index_without_ssl_verification_label = Don't verify SSL certificate ( useful at local development while using self-signed certificats )
+search_it_settings_index_host_label = Host[:Port] über den Indexiert wird
 
 search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess protection)
 search_it_settings_http_auth_desc = If the website i s protected through HTTP Basic Auth, you can put a valid login here, in order to allow indexing

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -28,10 +28,10 @@ search_it_settings_indexoffline = Index offline articles
 search_it_settings_automaticindex_label = Index and deindex articles automatically (ADD, EDIT, DELETE)
 search_it_settings_reindex_cols_onforms_label = Reindex all columns, if tables are changed through YForm or form
 search_it_settings_index_url_addon_label = Index URL addon (version >=2) URLs
-search_it_settings_index_without_ssl_verification_label = Don't verify SSL certificate ( useful at local development while using self-signed certificats )
-search_it_settings_index_host_label = Host[:Port] über den Indexiert wird
+search_it_settings_index_without_ssl_verification_label = Don't verify SSL certificate (useful at local development while using self-signed certificats)
+search_it_settings_index_host_label = Should indexing be done via a special host[:port]? (Please specify only if absolutely necessary)
 
-search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess protection)
+search_it_settings_http_authbasic = HTTP Basic AUTH (.htaccess protection)
 search_it_settings_http_auth_desc = If the website i s protected through HTTP Basic Auth, you can put a valid login here, in order to allow indexing
 search_it_settings_htaccess_user = Username
 search_it_settings_htaccess_pass = Password

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -28,6 +28,7 @@ search_it_settings_indexoffline = Artículo sin conexión de índice
 search_it_settings_automaticindex_label = Automáticamente indexar artículos (AGREGAR, EDITAR, ELIMINAR)
 search_it_settings_reindex_cols_onforms_label = Reindexar todas las columnas al editar tablas con YForm o formulario
 search_it_settings_index_url_addon_label = Index URL addon (version >=2) URLs
+search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen ( hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
 
 search_it_settings_http_authbasic = HTTP Basic AUTH (protección de contraseñas .htaccess)
 search_it_settings_http_auth_desc = Si una protección de acceso protege el sitio web, se puede almacenar un inicio de sesión aquí para permitir la indexación

--- a/lang/pt_br.lang
+++ b/lang/pt_br.lang
@@ -28,6 +28,7 @@ search_it_settings_indexoffline = Indexar artigos offline
 search_it_settings_automaticindex_label = Indexar e de-indexar artigos automaticamente (ADD, EDIT, DELETE)
 search_it_settings_reindex_cols_onforms_label = Re-indexar todas as colunas se as tabelas foram modificadas com Yform ou form
 search_it_settings_index_url_addon_label = Index URL addon (version >=2) URLs
+search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen ( hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
 
 search_it_settings_http_authbasic = HTTP Basic AUTH ( .htaccess Passwortschutz)
 search_it_settings_http_auth_desc = Wenn ein Zugriffsschutz die Website schützt, kann hier ein Login hinterlegt werden, um die Indexierung zu ermöglichen

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -216,6 +216,7 @@ class search_it
 
         $return = [];
         $keywords = [];
+
         foreach ($langs as $lang) {
             $langID = $lang->getId();
 
@@ -247,59 +248,74 @@ class search_it
                 AND ($_id != rex_article::getNotfoundArticleId() OR $_id == rex_article::getSiteStartArticleId())  ) {
 
 
-                 try {
-                        $scanurl = rtrim(rex::getServer(), "/") . '/' . ltrim(str_replace(array('../', './'), '', rex_getUrl($_id, $langID,array('search_it_build_index'=>'do-it'),'&')),"/");
-                        if(rex_addon::get("yrewrite") && rex_addon::get("yrewrite")->isAvailable()) {
-                            $scanurl = rex_yrewrite::getFullUrlByArticleId($_id, $langID, array('search_it_build_index' => 'do-it-with-yrewrite'), '&');
+                try {
+                    if (substr(rex_addon::get('search_it')->getConfig('index_host'),0,1) == ':') {
+                        $scanparts['port'] = trim(rex_addon::get('search_it')->getConfig('index_host'),':');
+                    } else {
+                        $scanparts = parse_url(rex_addon::get('search_it')->getConfig('index_host'));
+                    }
+
+                    if(rex_addon::get("yrewrite") && rex_addon::get("yrewrite")->isAvailable() && !isset($scanparts['host'])) {
+                        $scanurl = rex_yrewrite::getFullUrlByArticleId($_id, $langID, array('search_it_build_index' => 'do-it-with-yrewrite'), '&');
+                        if ( isset($scanparts['port']) && $scanparts['port'] != '' ) {
+                            $scanurl = str_replace(parse_url($scanurl,PHP_URL_HOST),parse_url($scanurl,PHP_URL_HOST).':'.$scanparts['port'], $scanurl);
                         }
+                    } else {
+                        $scanhost = ($scanparts['scheme'] ?? 'http' ).'://'.$scanparts['host'] ?? rex::getServer();
+                        $scanhost .= isset($scanparts['port']) ? ':'.$scanparts['port'] : '';
+                        $scanurl = rtrim($scanhost, "/") . '/' . ltrim(str_replace(array('../', './'), '', rex_getUrl($_id, $langID,array('search_it_build_index'=>'do-it'),'&')),"/");
+                    }
 
-                        $files_socket = rex_socket::factoryURL($scanurl);
-                        if (rex_addon::get('search_it')->getConfig('htaccess_user') != '' && rex_addon::get('search_it')->getConfig('htaccess_pass') != '') {
-                            $files_socket->addBasicAuthorization(rex_addon::get('search_it')->getConfig('htaccess_user'),rex_addon::get('search_it')->getConfig('htaccess_pass'));
+                    $scan_socket = $this->prepareSocket($scanurl);
+                    $response = $scan_socket->doGet();
+                    $redircount = 0;
+
+                    while ($response->isRedirection() && $redircount < 3) {
+                        $redircount++;
+                        $lastscanurl = $scanurl;
+                        $scanurl = str_replace(array('../', './'), '/',$response->getHeader('location'));
+
+                        $scanparts = parse_url($scanurl);
+                        if (in_array('query',$scanparts)) {
+                            list($scanurl, $parameters) = explode('?', $scanurl);
+                            parse_str($parameters, $output);
+                            unset($output['search_it_build_index']);
+                            $scanurl = $scanurl . '?' . http_build_query($output);
                         }
-                        $response = $files_socket->doGet();
-
-                        $redircount = 0;
-                        while ($response->isRedirection() && $redircount < 3) {
-
-                            $lastscanurl = $scanurl;
-                            $scanurl = str_replace(array('../', './'), '/',$response->getHeader('location'));
-
-                            if (strpos($scanurl,'//') === false ) {
-                                $parts = parse_url($lastscanurl);
-                                if ( isset($parts['scheme']) && isset($parts['host']) ) {
-                                    $scanurl = $parts['scheme'] . '://' . $parts['host'] . $scanurl;
-                                }
+                        if (!in_array('host',$scanparts)) {
+                            $lastparts = parse_url($lastscanurl);dump($lastparts);
+                            if ( isset($lastparts['scheme']) && isset($lastparts['host']) ) {
+                                $scanurl = $lastparts['scheme'] . '://' . $lastparts['host'] .
+                                ( isset($lastparts['port']) ? ':'.$lastparts['port'] : '' ).
+                                $scanurl;
                             }
-                            $scanurl .= ( strpos($scanurl,'?') !== false ? '&' : '?').'search_it_build_index=redirect';
-                            //rex_logger::factory()->log('Warning','Redirect von '.$lastscanurl.' zu '.$scanurl.', '.$response->getHeader());
-
-                            $files_socket = rex_socket::factoryURL($scanurl);
-                            if (rex_addon::get('search_it')->getConfig('htaccess_user') != '' && rex_addon::get('search_it')->getConfig('htaccess_pass') != '') {
-                                $files_socket->addBasicAuthorization(rex_addon::get('search_it')->getConfig('htaccess_user'),rex_addon::get('search_it')->getConfig('htaccess_pass'));
-                            }
-                            $response = $files_socket->doGet();
-                            $redircount++;
                         }
 
-                        if ($response->isOk()) {
-                            $articleText = $response->getBody();
+                        $scanurl .= ( strpos($scanurl,'?') !== false ? '&' : '?').'search_it_build_index=redirect';
+                        //rex_logger::factory()->log('Warning','Redirect von '.$lastscanurl.' zu '.$scanurl.', '.$response->getHeader());
+                        $scan_socket = $this->prepareSocket($scanurl);
+                        $response = $scan_socket->doGet();
+
+                    }
+
+                    if ($response->isOk()) {
+                        $articleText = $response->getBody();
+                    } else {
+                        $articleText = '';
+                        !is_null($response) ? $response_text = $response->getStatusCode() . ' - ' . $response->getStatusMessage() : $response_text = '';
+                        if ( $response->isRedirection() ) {
+                            $return[$langID] = SEARCH_IT_ART_REDIRECT;
+                            $response_text = rex_i18n::msg('search_it_generate_article_redirect');
+                            rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_http_error') .' '. $scanurl . PHP_EOL . $response_text );
+                        } else if ( $response->getStatusCode() == '404' ) {
+                            $return[$langID] = SEARCH_IT_ART_404;
+                            rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_404_error') .' '. $scanurl . PHP_EOL . $response_text );
                         } else {
-                            $articleText = '';
-                            !is_null($response) ? $response_text = $response->getStatusCode() . ' - ' . $response->getStatusMessage() : $response_text = '';
-                            if ( $response->isRedirection() ) {
-                                $return[$langID] = SEARCH_IT_ART_REDIRECT;
-                                $response_text = rex_i18n::msg('search_it_generate_article_redirect');
-                                rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_http_error') .' '. $scanurl . PHP_EOL . $response_text );
-                            } else if ( $response->getStatusCode() == '404' ) {
-                                $return[$langID] = SEARCH_IT_ART_404;
-                                rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_404_error') .' '. $scanurl . PHP_EOL . $response_text );
-                            } else {
-                                rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_http_error') .' '. $scanurl . PHP_EOL . $response_text );
-                                $return[$langID] = SEARCH_IT_ART_NOTOK;
-                            }
-                            continue;
+                            rex_logger::factory()->log( 'Warning', rex_i18n::msg('search_it_generate_article_http_error') .' '. $scanurl . PHP_EOL . $response_text );
+                            $return[$langID] = SEARCH_IT_ART_NOTOK;
                         }
+                        continue;
+                    }
 
                  } catch (rex_socket_exception $e) {
                     $articleText = '';
@@ -405,49 +421,62 @@ class search_it
 		}
 		else if (is_object($article) AND ($article->isOnline() OR rex_addon::get('search_it')->getConfig('indexoffline'))) {
 			try {
-				$url_profile = \Url\Profile::get($profile_id);
-				$server = rtrim(rex::getServer(), "/");
-				$search_it_build_index = "do-it";
-				if(rex_addon::get('yrewrite')->isAvailable()) {
+
+                if (substr(rex_addon::get('search_it')->getConfig('index_host'),0,1) == ':') {
+                    $scanparts['port'] = trim(rex_addon::get('search_it')->getConfig('index_host'),':');
+                } else {
+                    $scanparts = parse_url(rex_addon::get('search_it')->getConfig('index_host'));
+                }
+
+				if(rex_addon::get("yrewrite") && rex_addon::get('yrewrite')->isAvailable() && !isset($scanparts['host'])) {
 					$hit_domain = rex_yrewrite::getDomainByArticleId($article_id, $clang_id);
 					$server = rtrim($hit_domain->getUrl(), "/");
-					$search_it_build_index = "do-it-with-yrewrite";
-				}
+					$search_it_build_index = "do-it-url-with-yrewrite";
+                } else {
+                    $server = ($scanparts['scheme'] ?? 'http' ).'://'.$scanparts['host'] ?? rex::getServer();
+                    $server .= isset($scanparts['port']) ? ':'.$scanparts['port'] : '';
+                    $search_it_build_index = "do-it-url";
+                }
 
-				$scanurl = rex_getUrl($article_id, $clang_id, [$url_profile->getNamespace() => $data_id, 'search_it_build_index' => $search_it_build_index],'&');
+                $url_profile = \Url\Profile::get($profile_id);
+                $scanurl = rex_getUrl($article_id, $clang_id, [$url_profile->getNamespace() => $data_id, 'search_it_build_index' => $search_it_build_index],'&');
 				if(strpos($scanurl, 'http') === false) {
 					// URL addon multidomain site return server name in url
 					$scanurl = $server .'/'. ltrim(str_replace(['../', './'], '', $scanurl),"/");
 				}
 
-				$files_socket = rex_socket::factoryURL($scanurl);
-				if (rex_addon::get('search_it')->getConfig('htaccess_user') != '' && rex_addon::get('search_it')->getConfig('htaccess_pass') != '') {
-					$files_socket->addBasicAuthorization(rex_addon::get('search_it')->getConfig('htaccess_user'), rex_addon::get('search_it')->getConfig('htaccess_pass'));
-				}
-				$response = $files_socket->doGet();
-
+				$scan_socket = $this->prepareSocket($scanurl);
+				$response = $scan_socket->doGet();
 				$redircount = 0;
+dump($scanurl);
 				while ($response->isRedirection() && $redircount < 3) {
 
-					$lastscanurl = $scanurl;
-					$scanurl = str_replace(array('../', './'), '/', $response->getHeader('location'));
+                    $redircount++;
+                    $lastscanurl = $scanurl;
+                    $scanurl = str_replace(array('../', './'), '/',$response->getHeader('location'));
 
-					if (strpos($scanurl,'//') === false ) {
-						$parts = parse_url($lastscanurl);
-						if ( isset($parts['scheme']) && isset($parts['host']) ) {
-							$scanurl = $parts['scheme'] . '://' . $parts['host'] . $scanurl;
-						}
-					}
-					$scanurl .= ( strpos($scanurl,'?') !== false ? '&' : '?').'search_it_build_index=redirect';
+                    $scanparts = parse_url($scanurl);
+                    if (in_array('query',$scanparts)) {
+                        list($scanurl, $parameters) = explode('?', $scanurl);
+                        parse_str($parameters, $output);
+                        unset($output['search_it_build_index']);
+                        $scanurl = $scanurl . '?' . http_build_query($output);
+                    }
+                    if (!in_array('host',$scanparts)) {
+                        $lastparts = parse_url($lastscanurl);
+                        if ( isset($lastparts['scheme']) && isset($lastparts['host']) ) {
+                            $scanurl = $lastparts['scheme'] . '://' . $lastparts['host'] .
+                                ( isset($lastparts['port']) ? ':'.$lastparts['port'] : '' ).
+                                $scanurl;
+                        }
+                    }
+
+                    $scanurl .= ( strpos($scanurl,'?') !== false ? '&' : '?').'search_it_build_index=redirect';
 					//rex_logger::factory()->log('Warning','Redirect von '.$lastscanurl.' zu '.$scanurl.', '.$response->getHeader());
-
-					$files_socket = rex_socket::factoryURL($scanurl);
-					if (rex_addon::get('search_it')->getConfig('htaccess_user') != '' && rex_addon::get('search_it')->getConfig('htaccess_pass') != '') {
-						$files_socket->addBasicAuthorization(rex_addon::get('search_it')->getConfig('htaccess_user'),rex_addon::get('search_it')->getConfig('htaccess_pass'));
-					}
-					$response = $files_socket->doGet();
-					$redircount++;
+					$scan_socket->setPath($scanurl);
+					$response = $scan_socket->doGet();
 				}
+
 				if ($response->isOk()) {
 					$articleText = $response->getBody();
 				} else {
@@ -2474,5 +2503,23 @@ class search_it
         $return['time'] = microtime(true) - $startTime;
 
         return $return;
+    }
+
+    private function prepareSocket(string $scanurl)
+    {
+        $socket = rex_socket::factoryURL($scanurl);
+        if (rex_version::compare(rex::getVersion(), '5.13', '>=')) {
+            $socket->setOptions([
+                'ssl' => [
+                    'verify_peer' => false,
+                    'verify_peer_name' => false
+                ]
+            ]);
+        }
+        if (rex_addon::get('search_it')->getConfig('htaccess_user') != '' && rex_addon::get('search_it')->getConfig('htaccess_pass') != '') {
+            $socket->addBasicAuthorization(rex_addon::get('search_it')->getConfig('htaccess_user'),rex_addon::get('search_it')->getConfig('htaccess_pass'));
+        }
+
+        return $socket;
     }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '6.8.1'
+version: '6.9.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 

--- a/pages/settings.mode.php
+++ b/pages/settings.mode.php
@@ -17,6 +17,9 @@ if (rex_post('config-submit', 'boolean')) {
         ['reindex_cols_onforms', 'bool'],
         ['index_url_addon', 'bool'],
 
+        ['index_without_ssl_verification', 'bool'],
+        ['index_host', 'string'],
+
     ]);
 
     $changed = array_keys(array_merge(array_diff_assoc(array_map('serialize',$posted_config),array_map('serialize',$this->getConfig())), array_diff_assoc(array_map('serialize',$this->getConfig()),array_map('serialize',$posted_config))));
@@ -89,6 +92,22 @@ $content = search_it_getSettingsFormSection(
             'checked' => $this->getConfig('reindex_cols_onforms')
         ],
 		$url_checkbox
+        ,
+        [
+            'type' => 'checkbox',
+            'id' => 'search_it_index_without_ssl_verification',
+            'name' => 'search_config[index_without_ssl_verification]',
+            'label' => $this->i18n('search_it_settings_index_without_ssl_verification_label'),
+            'value' => '1',
+            'checked' => $this->getConfig('index_without_ssl_verification')
+        ],
+        [
+            'type' => 'string',
+            'id' => 'search_it_index_host',
+            'name' => 'search_config[index_host]',
+            'label' => $this->i18n('search_it_settings_index_host_label'),
+            'value' => !empty($this->getConfig('index_host')) ? rex_escape($this->getConfig('index_host')) : '',
+        ],
     ],'edit'
 );
 

--- a/pages/settings.mode.php
+++ b/pages/settings.mode.php
@@ -62,6 +62,18 @@ if(search_it_isUrlAddOnAvailable()) {
             'checked' => $this->getConfig('index_url_addon')
         ];
 }
+// SSL verify
+$ssl_verify = [];
+if (rex_version::compare(rex::getVersion(), '5.13', '>=')) {
+    $ssl_verify = [
+        'type' => 'checkbox',
+        'id' => 'search_it_index_without_ssl_verification',
+        'name' => 'search_config[index_without_ssl_verification]',
+        'label' => $this->i18n('search_it_settings_index_without_ssl_verification_label'),
+        'value' => '1',
+        'checked' => $this->getConfig('index_without_ssl_verification')
+    ];
+}
 
 $content = search_it_getSettingsFormSection(
     'search_it_index',
@@ -93,14 +105,8 @@ $content = search_it_getSettingsFormSection(
         ],
 		$url_checkbox
         ,
-        [
-            'type' => 'checkbox',
-            'id' => 'search_it_index_without_ssl_verification',
-            'name' => 'search_config[index_without_ssl_verification]',
-            'label' => $this->i18n('search_it_settings_index_without_ssl_verification_label'),
-            'value' => '1',
-            'checked' => $this->getConfig('index_without_ssl_verification')
-        ],
+        $ssl_verify
+        ,
         [
             'type' => 'string',
             'id' => 'search_it_index_host',

--- a/plugins/autocomplete/package.yml
+++ b/plugins/autocomplete/package.yml
@@ -1,5 +1,5 @@
 package: search_it/autocomplete
-version: '6.8.1'
+version: '6.9.0'
 author: Manétage
 
 title: 'translate:search_it_autocomplete_plugin_title'

--- a/plugins/documentation/docs/de_de/search_it-intro.md
+++ b/plugins/documentation/docs/de_de/search_it-intro.md
@@ -72,7 +72,7 @@ Bei der Installation werden fünf Datenbanktabellen angelegt:
 * Bleibt die Indextabelle leer, könnte ein .htaccess Zugriffsschutz die Indexierung verhindern.
 * Ggf. verhindert auch das aktivierte `Maintenance`-AddOn die Indexierung. `Search it` indexiert über das Frontend, weshalb das Frontend "offen" sein muss.
 * Bleibt die Indextabelle leer, ist eventuell ein "Minifier" im Einsatz, der HTML-Kommentare aus dem Quellcode entfernt.
-`Search it` benötigt HTML-Kommentare, um die zu indexierenden Inhalte zu markieren. Man kann auf den URL-Parameter 'search_it_build_index' prüfen, z.B. durch `rex_request('search_it_build_index', 'int', false)` - wenn er gesetzt ist, ist es ein Aufruf von `Search it`
+`Search it` benötigt HTML-Kommentare, um die zu indexierenden Inhalte zu markieren. Man kann auf den URL-Parameter 'search_it_build_index' prüfen, z.B. durch `rex_request('search_it_build_index', 'string', false)` - wenn er gesetzt ist, ist es ein Aufruf von `Search it`
 * Findet sich im syslog die Meldung `Warning: You should not use non-secure socket connections while connecting to "my-domain.tld"` so liegt dies daran, das die eigene Domain in den Einstellungen unter System (oder bei Verwendung von des Addons `YRewrite` in den Einstellungen dort) ohne `https://` eingetragen wurde.
 
 ### Wo finde ich weitere Hilfe?

--- a/plugins/documentation/docs/de_de/search_it-settings.md
+++ b/plugins/documentation/docs/de_de/search_it-settings.md
@@ -43,6 +43,13 @@ Dies sind die Standard-Einstellungen für den Aufbau eines Suchindex und die Dur
 
 Bei der Indexierung durchsucht Search it alle in den Einstellungen angegebenen Orte (Artikel, URLs aus dem URL-Addon, Datenbank, Medienpool) und erstellt einen Suchindex.
 
+##### SSL Zertifikat nicht überprüfen 
+Das kann hilfreich sein bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten )
+
+##### Host[:Port] 
+Falls die Hosting-Umgebung die Nutzung eines speziellen Hosts und/oder Ports nötig macht, kann man hier Host[:Port] angeben mit dem 
+dann die Indexierung durchgeführt wird. Das kann z.B. in einer Docker-Umgebung oder beim Einsatz hinter einem Proxy nötig sein.
+Wird diese Einstellung verwendet, kommt ein eventuell vorhandenes yrewrite nicht mehr zum Tragen.
 
 #### Suchmodi
 

--- a/plugins/documentation/package.yml
+++ b/plugins/documentation/package.yml
@@ -1,5 +1,5 @@
 package: search_it/documentation
-version: '6.8.1'
+version: '6.9.0'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_documentation_title'

--- a/plugins/plaintext/package.yml
+++ b/plugins/plaintext/package.yml
@@ -1,5 +1,5 @@
 package: search_it/plaintext
-version: '6.8.1'
+version: '6.9.0'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_plaintext_title'

--- a/plugins/stats/package.yml
+++ b/plugins/stats/package.yml
@@ -1,5 +1,5 @@
 package: search_it/stats
-version: '6.8.1'
+version: '6.9.0'
 author: Friends Of REDAXO
 
 title: 'translate:search_it_stats_plugin_title'


### PR DESCRIPTION
- NEU: host & port kann für den Indexierungsvorgang angegeben werden
- NEU ab REDAXO 5.13: Die Verifizierung des SSL-Zertifikat kann abgeschaltet werden (für lokale Entwicklung & selbst-ausgestellte Zertifikate)