### PR TITLE
added EP:: SEARCH_IT_INDEXARTICLE

### DIFF
--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -256,12 +256,11 @@ class search_it
             }
             
             //EP to check if Article should be indexed  
-            $indexcheck = rex_extension::registerPoint(new \rex_extension_point('SEARCH_IT_INDEXARTICLE', true, [
+            $doindex = rex_extension::registerPoint(new \rex_extension_point('SEARCH_IT_INDEX_ARTICLE', true, [
                 'article' => $article
             ]));
 
-            if($indexcheck === false)
-                {
+            if ($doindex === false) {
                 $return[$langID] = SEARCH_IT_ART_EXCLUDED;
                 continue;
             }

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -262,7 +262,7 @@ class search_it
 
             if($indexcheck === false)
                 {
-                $return[$langID] = SEARCH_IT_ART_IDNOTFOUND;
+                $return[$langID] = SEARCH_IT_ART_EXCLUDED;
                 continue;
             }
 		

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -254,7 +254,18 @@ class search_it
                 $return[$langID] = SEARCH_IT_ART_IDNOTFOUND;
                 continue;
             }
+            
+            //EP to check if Article should be indexed  
+            $indexcheck = rex_extension::registerPoint(new \rex_extension_point('SEARCH_IT_INDEXARTICLE', true, [
+                'article' => $article
+            ]));
 
+            if($indexcheck === false)
+                {
+                $return[$langID] = SEARCH_IT_ART_IDNOTFOUND;
+                continue;
+            }
+		
             if (is_object($article) and ($article->isOnline() or rex_addon::get('search_it')->getConfig('indexoffline')) and $_id != 0
                 and ($_id != rex_article::getNotfoundArticleId() or $_id == rex_article::getSiteStartArticleId())) {
 


### PR DESCRIPTION
Ermöglicht die Prüfung eines Artikels  in einem anderen Editor und somit die Beeinflussung der Indexierung.  Rückgabe true oder false. Bei false überspringt Search_it die Indexierung.

Anwendung im eigenen AddOn:

```PHP 
rex_extension::register('SEARCH_IT_INDEXARTICLE', function (rex_extension_point $ep) {
    // Hier Logik einfügen, um den Wert zu true oder false zu ändern
    // oder weitere Aktionen basierend auf dem $article-Objekt durchzuführen. via $article = $ep->getParam('article');
return true; 
});
```

Siehe auch: https://github.com/FriendsOfREDAXO/accessdenied/pull/43