### PR TITLE
feat: add searchNotInCategories() and searchNotInCategoryTree() (#299…

### DIFF
--- a/docs/02_index.md
+++ b/docs/02_index.md
@@ -162,6 +162,8 @@ $search_it = new SearchIt(REX_CLANG_ID); // Nur in einer bestimmten Sprache such
 
 # Artikel- / Struktur-Suche
 $search_it->searchInCategories([5, 6, 13]); // durchsucht nur die Kategorien 5, 6 und 13, oder
+$search_it->searchNotInCategories([8, 9]); // schließt die Kategorien 8 und 9 von den Ergebnissen aus, oder
+$search_it->searchNotInCategoryTree(8); // schließt Kategorie 8 inkl. Unterkategorien aus, oder
 $search_it->setSearchAllArticlesAnyway(false) // Keine Artikel durchsuchen
 ```
 

--- a/docs/05_reference.md
+++ b/docs/05_reference.md
@@ -32,6 +32,8 @@ Der alte Klassenname `search_it` funktioniert weiterhin (deprecated).
  `searchInArticles(array $ids): void`                           | Setzt die IDs der Artikel, in denen gesucht werden soll.
  `searchInCategories(array $ids): void`                         | Setzt die IDs der Kategorien, in denen gesucht werden soll.
  `searchInCategoryTree(int $id): void`                          | Setzt eine Kategorie als Wurzel — alle Artikel müssen darin enthalten sein.
+ `searchNotInCategories(array $ids): void`                      | Schließt die angegebenen Kategorien von den Suchergebnissen aus.
+ `searchNotInCategoryTree(int $id): void`                       | Schließt eine Kategorie inkl. aller Unterkategorien von den Suchergebnissen aus.
  `searchInFileCategories(array\|bool $ids): void`               | Setzt die IDs der Medienpool-Kategorien, in denen gesucht werden soll.
  `searchInDbColumn(string $table, string $column): void`        | Beschränkt die Suche auf bestimmte Datenbankspalten.
  `setSearchAllArticlesAnyway(bool $bool = false): void`         | Legt fest, ob Artikel durchsucht werden sollen.

--- a/docs/20_faq.md
+++ b/docs/20_faq.md
@@ -52,6 +52,30 @@ $search_it->searchInCategoryTree(5); // 5 = ID der Kategorie, sucht rekursiv
 $result = $search_it->search(rex_request('search', 'string'));
 ```
 
+### Bestimmte Kategorien von der Suche ausschließen
+
+Manchmal sollen bestimmte Kategorien nicht in den Suchergebnissen auftauchen, ohne sie komplett vom Index auszuschließen. Die Artikel bleiben indexiert, werden aber bei dieser Suche nicht geliefert.
+
+**Bestimmte Kategorien ausschließen**
+
+```php
+use FriendsOfRedaxo\SearchIt\SearchIt;
+
+$search_it = new SearchIt();
+$search_it->searchNotInCategories([5, 12]); // schließt die Kategorien 5 und 12 aus
+$result = $search_it->search(rex_request('search', 'string'));
+```
+
+**Kategorie inkl. Unterkategorien ausschließen**
+
+```php
+use FriendsOfRedaxo\SearchIt\SearchIt;
+
+$search_it = new SearchIt();
+$search_it->searchNotInCategoryTree(5); // schließt Kategorie 5 und alle Unterkategorien aus
+$result = $search_it->search(rex_request('search', 'string'));
+```
+
 ### Multidomains mit YRewrite, Suche auf Domain eingrenzen
 
 > Wie funktioniert Search it in Kombination mit YRewrite mit verschiedenen

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -88,6 +88,7 @@ class SearchIt
     private bool $cache = true;
     private array $cachedArray = [];
     private array $searchInIDs = [];
+    private array $excludeCategoryIDs = [];
     private bool $searchAllArticlesAnyway = false;
     private array $whitelist = [];
 
@@ -1612,6 +1613,32 @@ class SearchIt
     }
 
     /**
+     * Excludes the given categories from the search results.
+     *
+     * Expects an array with category IDs as parameter.
+     */
+    public function searchNotInCategories(array $_ids): void
+    {
+        foreach ($_ids as $id) {
+            if ($id = intval($id)) {
+                $this->excludeCategoryIDs[] = $id;
+                $this->hashMe .= 'nc' . $id;
+            }
+        }
+    }
+
+    /**
+     * Excludes a category and all its subcategories from the search results.
+     *
+     * Expects a category ID as parameter.
+     */
+    public function searchNotInCategoryTree(int $_id): void
+    {
+        $subcats = self::getChildList($_id);
+        $this->searchNotInCategories($subcats);
+    }
+
+    /**
      * Retrieves a list of IDs of all categories which are subcategories to the given one.
      *
      * Expects a category ID as parameter.
@@ -2441,6 +2468,10 @@ class SearchIt
             } else {
                 $where .= ' AND (' . implode(' AND ', $AwhereToSearch) . ')';
             }
+        }
+
+        if (!empty($this->excludeCategoryIDs)) {
+            $where .= ' AND (catid IS NULL OR catid NOT IN (' . implode(',', $this->excludeCategoryIDs) . '))';
         }
 
         if (!empty($this->where)) {


### PR DESCRIPTION
…, #315)

Allow excluding specific categories from search results at query time, without removing them from the index entirely.