### PR TITLE
fix: show teaser text instead of empty highlightedtext (#292)

### DIFF
--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2051,6 +2051,9 @@ class SearchIt
                         $return .= ' ' . $this->ellipsis;
                     }
                 }
+                if ($return === '') {
+                    return $this->getTeaserText($_text);
+                }
                 return $return;
                 break;
 
@@ -2116,6 +2119,10 @@ class SearchIt
 
                 if ($this->highlightType == 'array') {
                     return $Ahighlighted;
+                }
+
+                if (empty($Ahighlighted)) {
+                    return $this->getTeaserText($_text);
                 }
 
                 $return = implode(' ' . $this->ellipsis . ' ', $Ahighlighted);


### PR DESCRIPTION
When the regex-based highlighting fails to match the search term in the plaintext (e.g. due to special characters), fall back to the teaser text instead of returning an empty string or just ellipsis. closes #292