### PR TITLE
feat: add configurable logging for article and URL addon indexing

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -31,6 +31,8 @@ search_it_settings_automaticindex_label = Artikel (ADD, EDIT, DELETE) automatisc
 search_it_settings_reindex_cols_onforms_label = Reindexieren aller Spalten, wenn Tabellen mit YForm oder form bearbeitet werden
 search_it_settings_index_url_addon_label = URLs aus dem URL Addon (Version >=2) indexieren
 search_it_settings_index_without_ssl_verification_label = SSL Zertifikat nicht überprüfen (hilfreich bei lokaler Entwicklung und der Nutzung von selbst-zertifizierten Zertifikaten)
+search_it_settings_logging_articles_label = Indexierungsmeldungen für Artikel loggen (Warnungen, Fehler)
+search_it_settings_logging_urls_label = Indexierungsmeldungen für URL-Addon-URLs loggen (Warnungen, Fehler)
 search_it_settings_index_special_title = Spezial
 search_it_settings_dont_use_socket_active = Die Einstellung <code>dont_use_socket</code> ist aktiv. Die Indexierung erfolgt ohne HTTP-Verbindung, daher haben HTTP Auth und Index-URL keine Wirkung.
 search_it_settings_index_url_title = Index-URL

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -31,6 +31,8 @@ search_it_settings_automaticindex_label = Index and deindex articles automatical
 search_it_settings_reindex_cols_onforms_label = Reindex all columns, if tables are changed through YForm or form
 search_it_settings_index_url_addon_label = Index URL addon (version >=2) URLs
 search_it_settings_index_without_ssl_verification_label = Don't verify SSL certificate (useful at local development while using self-signed certificats)
+search_it_settings_logging_articles_label = Log indexing messages for articles (warnings, errors)
+search_it_settings_logging_urls_label = Log indexing messages for URL addon URLs (warnings, errors)
 search_it_settings_index_special_title = Special
 search_it_settings_dont_use_socket_active = The setting <code>dont_use_socket</code> is active. Indexing is done without HTTP connection, so HTTP Auth and Index URL have no effect.
 search_it_settings_index_url_title = Index URL

--- a/lib/Helper/Logger.php
+++ b/lib/Helper/Logger.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FriendsOfRedaxo\SearchIt\Helper;
+
+use rex_addon;
+use rex_logger;
+
+class Logger
+{
+    private const CHANNEL_ARTICLES = 'logging_articles';
+    private const CHANNEL_URLS = 'logging_urls';
+
+    private static function isEnabled(string $channel): bool
+    {
+        return (bool) rex_addon::get('search_it')->getConfig($channel, true);
+    }
+
+    public static function logArticle(string $level, string $message): void
+    {
+        if (self::isEnabled(self::CHANNEL_ARTICLES)) {
+            rex_logger::factory()->log($level, $message);
+        }
+    }
+
+    public static function logUrl(string $level, string $message): void
+    {
+        if (self::isEnabled(self::CHANNEL_URLS)) {
+            rex_logger::factory()->log($level, $message);
+        }
+    }
+}

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2,6 +2,7 @@
 
 namespace FriendsOfRedaxo\SearchIt;
 
+use FriendsOfRedaxo\SearchIt\Helper\Logger;
 use FriendsOfRedaxo\SearchIt\Pdf\PdfConverter;
 use rex;
 use rex_addon;
@@ -16,7 +17,6 @@ use rex_extension;
 use rex_extension_point;
 use rex_file;
 use rex_i18n;
-use rex_logger;
 use rex_path;
 use rex_request;
 use rex_socket;
@@ -381,7 +381,7 @@ class SearchIt
 
                         // Check if URL uses a valid HTTP/HTTPS scheme before attempting socket connection
                         if (!$this->isValidHttpScheme($scanurl)) {
-                            rex_logger::factory()->info('Search_it: Skipping indexing of article ' . $_id . ' with non-HTTP scheme URL: ' . $scanurl);
+                            Logger::logArticle('info', 'Search_it: Skipping indexing of article ' . $_id . ' with non-HTTP scheme URL: ' . $scanurl);
                             $return[$langID] = self::ART_EXCLUDED;
                             continue;
                         }
@@ -416,7 +416,7 @@ class SearchIt
 
                             // Check if redirect URL uses a valid HTTP/HTTPS scheme
                             if (!$this->isValidHttpScheme($scanurl)) {
-                                rex_logger::factory()->info('Search_it: Stopping redirect follow for article ' . $_id . ' - redirect to non-HTTP scheme URL: ' . $scanurl);
+                                Logger::logArticle('info', 'Search_it: Stopping redirect follow for article ' . $_id . ' - redirect to non-HTTP scheme URL: ' . $scanurl);
                                 break; // Stop following redirects if we hit a non-HTTP scheme
                             }
 
@@ -433,12 +433,12 @@ class SearchIt
                             if ($response->isRedirection()) {
                                 $return[$langID] = self::ART_REDIRECT;
                                 $response_text = rex_i18n::msg('search_it_generate_article_redirect');
-                                rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                                Logger::logArticle('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                             } else if ($response->getStatusCode() == '404') {
                                 $return[$langID] = self::ART_404;
-                                rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_404_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                                Logger::logArticle('Warning', rex_i18n::msg('search_it_generate_article_404_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                             } else {
-                                rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                                Logger::logArticle('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                                 $return[$langID] = self::ART_NOTOK;
                             }
                             continue;
@@ -446,7 +446,7 @@ class SearchIt
 
                     } catch (rex_socket_exception $e) {
                         $articleText = '';
-                        rex_logger::factory()->error(rex_i18n::msg('search_it_generate_article_socket_error') . ': ' . $scanurl . PHP_EOL . $e->getMessage());
+                        Logger::logArticle('error', rex_i18n::msg('search_it_generate_article_socket_error') . ': ' . $scanurl . PHP_EOL . $e->getMessage());
                         $return[$langID] = self::ART_ERROR;
                         continue;
 
@@ -607,7 +607,7 @@ class SearchIt
 
                 // Check if URL uses a valid HTTP/HTTPS scheme before attempting socket connection
                 if (!$this->isValidHttpScheme($scanurl)) {
-                    rex_logger::factory()->info('Search_it: Skipping indexing of URL with non-HTTP scheme: ' . $scanurl);
+                    Logger::logUrl('info', 'Search_it: Skipping indexing of URL with non-HTTP scheme: ' . $scanurl);
                     $return[$clang_id] = self::URL_EXCLUDED;
                     return $return;
                 }
@@ -643,7 +643,7 @@ class SearchIt
 
                     // Check if redirect URL uses a valid HTTP/HTTPS scheme
                     if (!$this->isValidHttpScheme($scanurl)) {
-                        rex_logger::factory()->info('Search_it: Stopping redirect follow for URL - redirect to non-HTTP scheme URL: ' . $scanurl);
+                        Logger::logUrl('info', 'Search_it: Stopping redirect follow for URL - redirect to non-HTTP scheme URL: ' . $scanurl);
                         break; // Stop following redirects if we hit a non-HTTP scheme
                     }
 
@@ -658,12 +658,12 @@ class SearchIt
                     if ($response->isRedirection()) {
                         $return[$clang_id] = self::URL_REDIRECT;
                         $response_text = rex_i18n::msg('search_it_generate_article_redirect');
-                        rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                        Logger::logUrl('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                     } else if ($response->getStatusCode() == '404') {
                         $return[$clang_id] = self::URL_404;
-                        rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_404_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                        Logger::logUrl('Warning', rex_i18n::msg('search_it_generate_article_404_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                     } else {
-                        rex_logger::factory()->log('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
+                        Logger::logUrl('Warning', rex_i18n::msg('search_it_generate_article_http_error') . ' ' . $scanurl . PHP_EOL . $response_text);
                         $return[$clang_id] = self::URL_NOTOK;
                     }
                     return $return;
@@ -671,7 +671,7 @@ class SearchIt
 
             } catch (rex_socket_exception $e) {
                 $articleText = '';
-                rex_logger::factory()->error(rex_i18n::msg('search_it_generate_article_socket_error') . ' ' . $scanurl . PHP_EOL . $e->getMessage());
+                Logger::logUrl('error', rex_i18n::msg('search_it_generate_article_socket_error') . ' ' . $scanurl . PHP_EOL . $e->getMessage());
                 $return[$clang_id] = self::URL_ERROR;
             }
 
@@ -902,11 +902,11 @@ class SearchIt
     {
         $sqltest = rex_sql_table::get($_table);
         if (!$sqltest->exists()) {
-            rex_logger::factory()->log('Warning', rex_i18n::rawMsg('search_it_generate_table_not_exists', $_table));
+            Logger::logArticle('Warning', rex_i18n::rawMsg('search_it_generate_table_not_exists', $_table));
             return false;
         } else {
             if (!$sqltest->hasColumn($_column)) {
-                rex_logger::factory()->log('Warning', rex_i18n::rawMsg('search_it_generate_col_not_exists', $_column, $_table));
+                Logger::logArticle('Warning', rex_i18n::rawMsg('search_it_generate_col_not_exists', $_column, $_table));
                 return false;
             }
         }

--- a/pages/settings.index.php
+++ b/pages/settings.index.php
@@ -15,6 +15,8 @@ if (rex_post('config-submit', 'boolean')) {
 
         ['index_without_ssl_verification', 'bool'],
         ['index_host', 'string'],
+        ['logging_articles', 'bool'],
+        ['logging_urls', 'bool'],
 
     ]);
 
@@ -99,6 +101,22 @@ $content3[] = search_it_getSettingsFormSection(
         ,
         $ssl_verify
         ,
+        [
+            'type' => 'checkbox',
+            'id' => 'search_it_logging_articles',
+            'name' => 'search_config[logging_articles]',
+            'label' => $this->i18n('search_it_settings_logging_articles_label'),
+            'value' => '1',
+            'checked' => $this->getConfig('logging_articles') ?? true
+        ],
+        [
+            'type' => 'checkbox',
+            'id' => 'search_it_logging_urls',
+            'name' => 'search_config[logging_urls]',
+            'label' => $this->i18n('search_it_settings_logging_urls_label'),
+            'value' => '1',
+            'checked' => $this->getConfig('logging_urls') ?? true
+        ],
     ], 'edit'
 );
 


### PR DESCRIPTION
Introduces a Logger helper class that checks two new settings before writing to rex_logger. Both options default to enabled (no behavior change for existing installations). Users can now disable logging individually for articles and URL addon URLs.
closes #415