### PR TITLE
replace class_alias() calls with deprecated class stubs, version 7.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## Version 7.1.4 (2026-03-26)
+- Replace class_alias() with deprecated class stubs thx @christophboecker (#463)
+
 ## Version 7.1.3 (2026-03-18)
-- Fix: Cronjob-Migration in install.php prüft jetzt ob die Cronjob-Tabelle existiert und verwendet die korrekten Klassennamen 
+- Fix: Cronjob-Migration in install.php prüft jetzt ob die Cronjob-Tabelle existiert und verwendet die korrekten Klassennamen
 - Fix: Autocomplete-Dropdown wird direkt am Eingabefeld positioniert (relative statt absolute Positionierung am Body) thx @rotzek (#470)
-- Fix: replace class_alias() with deprecated Classes for rex_stan and other tools thx @christophboecker (#463)
 - Fix: Native Browser-Autocomplete wird bei aktivem Suggest deaktiviert
 
 ## Version 7.1.2 (2026-03-14)

--- a/boot.php
+++ b/boot.php
@@ -7,20 +7,7 @@ use FriendsOfRedaxo\SearchIt\EventHandler;
 use FriendsOfRedaxo\SearchIt\Plaintext\PlaintextConverter;
 use FriendsOfRedaxo\SearchIt\Search\Highlighter;
 
-/**
- * Backward compatibility class aliases.
- * @deprecated Use the namespaced classes instead.
- */
-class_alias(SearchIt::class, 'search_it');
 rex_api_function::register('search_it_autocomplete', FriendsOfRedaxo\SearchIt\Api\Autocomplete::class);
-class_alias(FriendsOfRedaxo\SearchIt\Stats\Statistics::class, 'search_it_stats');
-class_alias(FriendsOfRedaxo\SearchIt\Pdf\PdfConverter::class, 'pdf2txt');
-if (rex_addon::get('cronjob')->isAvailable()) {
-    class_alias(Reindex::class, 'rex_cronjob_Reindex');
-    class_alias(ClearCache::class, 'rex_cronjob_ClearCache');
-}
-class_alias(FriendsOfRedaxo\SearchIt\Console\ReindexCommand::class, 'rex_search_it_command_reindex');
-class_alias(FriendsOfRedaxo\SearchIt\Console\ClearCacheCommand::class, 'rex_search_it_command_clearcache');
 
 /**
  * @deprecated Use SearchIt::ART_*, SearchIt::URL_*, SearchIt::FILE_*, SearchIt::SIMILARWORDS_* instead.

--- a/lib/deprecated.php
+++ b/lib/deprecated.php
@@ -1,0 +1,29 @@
+<?php
+
+class search_it extends \FriendsOfRedaxo\SearchIt\SearchIt
+{
+}
+
+class search_it_stats extends \FriendsOfRedaxo\SearchIt\Stats\Statistics
+{
+}
+
+class pdf2txt extends \FriendsOfRedaxo\SearchIt\Pdf\PdfConverter
+{
+}
+
+class rex_search_it_command_reindex extends \FriendsOfRedaxo\SearchIt\Console\ReindexCommand
+{
+}
+
+class rex_search_it_command_clearcache extends \FriendsOfRedaxo\SearchIt\Console\ClearCacheCommand
+{
+}
+
+class rex_cronjob_reindex extends \FriendsOfRedaxo\SearchIt\Cronjob\Reindex
+{
+}
+
+class rex_cronjob_clearcache extends \FriendsOfRedaxo\SearchIt\Cronjob\ClearCache
+{
+}

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '7.1.3'
+version: '7.1.4'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 


### PR DESCRIPTION
Backward compatibility is now handled via lib/deprecated.php which defines empty subclasses of the namespaced classes. 
This is an approach suitable for static code analytic tools and allows the autoloader to resolve old class names without boot-time class_alias() calls.