### PR TITLE
Fix fatal error when cronjob addon is not installed

### DIFF
--- a/lib/deprecated.php
+++ b/lib/deprecated.php
@@ -20,10 +20,12 @@ class rex_search_it_command_clearcache extends \FriendsOfRedaxo\SearchIt\Console
 {
 }
 
-class rex_cronjob_reindex extends \FriendsOfRedaxo\SearchIt\Cronjob\Reindex
-{
-}
+if (class_exists('rex_cronjob')) {
+    class rex_cronjob_reindex extends \FriendsOfRedaxo\SearchIt\Cronjob\Reindex
+    {
+    }
 
-class rex_cronjob_clearcache extends \FriendsOfRedaxo\SearchIt\Cronjob\ClearCache
-{
+    class rex_cronjob_clearcache extends \FriendsOfRedaxo\SearchIt\Cronjob\ClearCache
+    {
+    }
 }


### PR DESCRIPTION
The deprecated class stubs for rex_cronjob_reindex and rex_cronjob_clearcache unconditionally extend classes that inherit from rex_cronjob. When deprecated.php is loaded by the autoloader (e.g. to resolve the old search_it class name), PHP tries to resolve the full inheritance chain and fails with "Class rex_cronjob not found" if the cronjob addon is not installed.

Wrap the two cronjob compatibility classes in a class_exists() guard so they are only defined when rex_cronjob is actually available.