### PR TITLE
Version 7.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 7.1.5 (2026-03-26)
+- Fix: URL-Addon-Treffer werden bei Category-Tree-Suche nicht mehr ausgefiltert thx @iriswerner (#478)
+- Fix: "Class rex_cronjob not found" wenn Cronjob-Addon nicht installiert und deprecated Klassenname referenziert wird thx @V-Simos (#476)
+
 ## Version 7.1.4 (2026-03-26)
 - Replace class_alias() with deprecated class stubs thx @christophboecker (#463)
 

--- a/lib/deprecated.php
+++ b/lib/deprecated.php
@@ -20,10 +20,3 @@ class rex_search_it_command_clearcache extends \FriendsOfRedaxo\SearchIt\Console
 {
 }
 
-class rex_cronjob_reindex extends \FriendsOfRedaxo\SearchIt\Cronjob\Reindex
-{
-}
-
-class rex_cronjob_clearcache extends \FriendsOfRedaxo\SearchIt\Cronjob\ClearCache
-{
-}

--- a/lib/deprecated_cronjob.php
+++ b/lib/deprecated_cronjob.php
@@ -1,0 +1,9 @@
+<?php
+
+class rex_cronjob_reindex extends \FriendsOfRedaxo\SearchIt\Cronjob\Reindex
+{
+}
+
+class rex_cronjob_clearcache extends \FriendsOfRedaxo\SearchIt\Cronjob\ClearCache
+{
+}

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -2451,7 +2451,14 @@ class SearchIt
         }
 
         if (array_key_exists('categories', $this->searchInIDs) and count($this->searchInIDs['categories'])) {
-            $AwhereToSearch[] = "(ISNULL(catid) OR (catid IN (" . implode(',', $this->searchInIDs['categories']) . ") AND ftable = '" . self::getTablePrefix() . "article'))";
+            $inCatIds = implode(',', $this->searchInIDs['categories']);
+            $catCondition = "(ISNULL(catid) OR (catid IN (" . $inCatIds . ") AND ftable = '" . self::getTablePrefix() . "article')";
+
+            if (rex_addon::get('search_it')->getConfig('index_url_addon') && UrlAddon::isAvailable() && $this->urlAddOnTableName) {
+                $catCondition .= " OR (catid IN (" . $inCatIds . ") AND ftable = '" . $this->urlAddOnTableName . "')";
+            }
+
+            $AwhereToSearch[] = $catCondition . ")";
         }
 
         if (array_key_exists('filecategories', $this->searchInIDs) and count($this->searchInIDs['filecategories'])) {

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '7.1.4'
+version: '7.1.5'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 


### PR DESCRIPTION
## Version 7.1.5 (2026-03-26)
- Fix: URL-Addon-Treffer werden bei Category-Tree-Suche nicht mehr ausgefiltert thx @iriswerner (#478)
- Fix: "Class rex_cronjob not found" wenn Cronjob-Addon nicht installiert und deprecated Klassenname referenziert wird thx @V-Simos (#476)
