### PR TITLE
API-Endpunkte für api-Addon in search_it inkl. Public-Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Version 6.10.0 (2026-05-30)
+- NEU: API-Endpunkte fuer das Addon `api` hinzugefuegt (`search_it/capabilities`, `search_it/search`, `search_it/reindex`)
+- NEU: Oeffentlicher Endpunkt `search_it/public/search` ohne Bearer-Token
+- API-Auth-Konzept: geschuetzte Routen via Bearer-Auth, Backend-Spiegelrouten via BackendUser-Auth
+- Public-Search mit Schutzgrenzen (mindestens 2 Zeichen Suchbegriff, `limit_count` auf max. 20 gekappt)
+
 ## Version 6.9.10 (2023-10-21)
 - Security Fix: escape Suchbegriffe
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 ## Version 6.10.0 (2026-05-30)
-- NEU: API-Endpunkte fuer das Addon `api` hinzugefuegt (`search_it/capabilities`, `search_it/search`, `search_it/reindex`)
-- NEU: Oeffentlicher Endpunkt `search_it/public/search` ohne Bearer-Token
-- API-Auth-Konzept: geschuetzte Routen via Bearer-Auth, Backend-Spiegelrouten via BackendUser-Auth
+- NEU: API-Endpunkte für das Addon `api` hinzugefügt (`search_it/capabilities`, `search_it/search`, `search_it/reindex`)
+- NEU: Öffentlicher Endpunkt `search_it/public/search` ohne Bearer-Token
+- API-Auth-Konzept: geschützte Routen via Bearer-Auth, Backend-Spiegelrouten via BackendUser-Auth
 - Public-Search mit Schutzgrenzen (mindestens 2 Zeichen Suchbegriff, `limit_count` auf max. 20 gekappt)
 
 ## Version 6.9.10 (2023-10-21)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,48 @@ miteinbezogen.
 Nach der Installation sollten zunächst die Einstellungen vorgenommen werden und
 anschließend der Index vollständig generiert werden.
 
+## API-Endpunkte (Addon api)
+
+Wenn das Addon `api` installiert und aktiv ist, registriert search_it eigene
+Endpunkte.
+
+### Geschuetzte Endpunkte (Bearer)
+
+Diese Endpunkte erfordern einen gueltigen Bearer-Token:
+
+* `GET /api/search_it/capabilities`
+* `GET /api/search_it/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10`
+* `POST /api/search_it/reindex`
+
+Beispiel:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "https://example.org/api/search_it/search?q=test"
+```
+
+### Oeffentlicher Endpunkt (ohne Bearer)
+
+Der folgende Endpunkt ist oeffentlich erreichbar:
+
+* `GET /api/search_it/public/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10`
+
+Schutzgrenzen fuer den oeffentlichen Zugriff:
+
+* Suchbegriff muss mindestens 2 Zeichen lang sein
+* `limit_count` wird auf maximal 20 begrenzt
+
+Beispiel:
+
+```bash
+curl "https://example.org/api/search_it/public/search?q=test"
+```
+
+### Backend-Spiegelrouten
+
+Die search_it-Scopes werden zusaetzlich als `backend/...`-Routen registriert
+und dort ueber `BackendUser` abgesichert.
+
 ## Lizenz
 
 [MIT Lizenz](https://github.com/FriendsOfREDAXO/search_it/blob/master/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ anschließend der Index vollständig generiert werden.
 Wenn das Addon `api` installiert und aktiv ist, registriert search_it eigene
 Endpunkte.
 
-### Geschuetzte Endpunkte (Bearer)
+### Geschützte Endpunkte (Bearer)
 
-Diese Endpunkte erfordern einen gueltigen Bearer-Token:
+Diese Endpunkte erfordern einen gültigen Bearer-Token:
 
 * `GET /api/search_it/capabilities`
 * `GET /api/search_it/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10`
@@ -74,13 +74,13 @@ curl -H "Authorization: Bearer <token>" \
   "https://example.org/api/search_it/search?q=test"
 ```
 
-### Oeffentlicher Endpunkt (ohne Bearer)
+### Öffentlicher Endpunkt (ohne Bearer)
 
-Der folgende Endpunkt ist oeffentlich erreichbar:
+Der folgende Endpunkt ist öffentlich erreichbar:
 
 * `GET /api/search_it/public/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10`
 
-Schutzgrenzen fuer den oeffentlichen Zugriff:
+Schutzgrenzen für den öffentlichen Zugriff:
 
 * Suchbegriff muss mindestens 2 Zeichen lang sein
 * `limit_count` wird auf maximal 20 begrenzt
@@ -93,8 +93,8 @@ curl "https://example.org/api/search_it/public/search?q=test"
 
 ### Backend-Spiegelrouten
 
-Die search_it-Scopes werden zusaetzlich als `backend/...`-Routen registriert
-und dort ueber `BackendUser` abgesichert.
+Die search_it-Scopes werden zusätzlich als `backend/...`-Routen registriert
+und dort über `BackendUser` abgesichert.
 
 ## Lizenz
 

--- a/boot.php
+++ b/boot.php
@@ -1,4 +1,9 @@
 <?php
+
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\SearchIt\Api\RoutePackage\Backend\SearchIt as ApiBackendSearchItRoutePackage;
+use FriendsOfRedaxo\SearchIt\Api\RoutePackage\SearchIt as ApiSearchItRoutePackage;
+
 if (!defined('SEARCH_IT_ART_EXCLUDED')) {
     define('SEARCH_IT_ART_EXCLUDED', 0);
     define('SEARCH_IT_ART_IDNOTFOUND', 1);
@@ -33,6 +38,11 @@ if (!defined('SEARCH_IT_ART_EXCLUDED')) {
 
 $curDir = __DIR__;
 require_once $curDir . '/functions/functions_search_it.php';
+
+if (rex_addon::get('api')->isAvailable() && class_exists(RouteCollection::class)) {
+    RouteCollection::registerRoutePackage(new ApiSearchItRoutePackage());
+    RouteCollection::registerRoutePackage(new ApiBackendSearchItRoutePackage());
+}
 
 if (rex_request('search_highlighter', 'string', '') != '' && rex_addon::get('search_it')->getConfig('highlighterclass') != '') {
     rex_extension::register('OUTPUT_FILTER', 'search_it_search_highlighter_output');

--- a/lib/Api/RoutePackage/Backend/SearchIt.php
+++ b/lib/Api/RoutePackage/Backend/SearchIt.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FriendsOfRedaxo\SearchIt\Api\RoutePackage\Backend;
+
+use FriendsOfRedaxo\Api\Auth\BackendUser;
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\SearchIt\Api\RoutePackage\SearchIt as TokenSearchIt;
+
+use function strlen;
+
+class SearchIt extends TokenSearchIt
+{
+    public function loadRoutes()
+    {
+        $routes = RouteCollection::getRoutes();
+
+        foreach ($routes as $route) {
+            if ('search_it/' === substr($route['scope'], 0, strlen('search_it/'))) {
+                $scope = 'backend/' . $route['scope'];
+                $newRoute = clone $route['route'];
+                $newRoute->setPath('backend/' . ltrim($newRoute->getPath(), '/'));
+
+                RouteCollection::registerRoute(
+                    $scope,
+                    $newRoute,
+                    $route['description'],
+                    $route['responses'],
+                    new BackendUser(),
+                    ['backend']
+                );
+            }
+        }
+    }
+}

--- a/lib/Api/RoutePackage/SearchIt.php
+++ b/lib/Api/RoutePackage/SearchIt.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace FriendsOfRedaxo\SearchIt\Api\RoutePackage;
+
+use Exception;
+use FriendsOfRedaxo\Api\Auth\BearerAuth;
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\Api\RoutePackage;
+use rex_addon;
+use rex_clang;
+use rex;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
+
+use const JSON_PRETTY_PRINT;
+
+class SearchIt extends RoutePackage
+{
+    public function loadRoutes()
+    {
+        RouteCollection::registerRoute(
+            'search_it/public/search',
+            new Route(
+                'search_it/public/search',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handlePublicSearch',
+                    'query' => [
+                        'q' => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_start' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_count' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 10,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET']
+            ),
+            'Execute a public search_it query without bearer token',
+            null,
+            null,
+            ['search_it']
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/capabilities',
+            new Route(
+                'search_it/capabilities',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleCapabilities',
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET']
+            ),
+            'Get search_it capabilities and addon configuration snapshot',
+            null,
+            new BearerAuth(),
+            ['search_it']
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/search',
+            new Route(
+                'search_it/search',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleSearch',
+                    'query' => [
+                        'q' => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_start' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_count' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 10,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET']
+            ),
+            'Execute a search_it fulltext query',
+            null,
+            new BearerAuth(),
+            ['search_it']
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/reindex',
+            new Route(
+                'search_it/reindex',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleReindex',
+                    'Body' => [
+                        'article_id' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => -1,
+                        ],
+                        'clear_cache' => [
+                            'type' => 'bool',
+                            'required' => false,
+                            'default' => true,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['POST']
+            ),
+            'Reindex search_it data (full or per article)',
+            null,
+            new BearerAuth(),
+            ['search_it']
+        );
+    }
+
+    /** @api */
+    public static function handleCapabilities($parameter, array $route = []): Response
+    {
+        $addon = rex_addon::get('search_it');
+
+        $payload = [
+            'addon' => 'search_it',
+            'version' => $addon->getVersion(),
+            'config' => [
+                'searchmode' => $addon->getConfig('searchmode'),
+                'logicalmode' => $addon->getConfig('logicalmode'),
+                'highlight' => $addon->getConfig('highlight'),
+                'limit' => $addon->getConfig('limit'),
+                'indexoffline' => (bool) $addon->getConfig('indexoffline'),
+                'index_url_addon' => (bool) $addon->getConfig('index_url_addon'),
+                'indexmediapool' => (bool) $addon->getConfig('indexmediapool'),
+            ],
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handleSearch($parameter, array $route = []): Response
+    {
+        try {
+            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+        }
+
+        $searchTerm = trim((string) ($query['q'] ?? ''));
+        if ('' === $searchTerm) {
+            return new Response(json_encode(['error' => 'q must not be empty']), 400);
+        }
+
+        $clang = (int) ($query['clang'] ?? 0);
+        if ($clang <= 0) {
+            $clang = rex_clang::getCurrentId();
+        }
+
+        $limitStart = max(0, (int) ($query['limit_start'] ?? 0));
+        $limitCount = max(1, (int) ($query['limit_count'] ?? 10));
+
+        $search = new \search_it($clang);
+        $search->setLimit([$limitStart, $limitCount]);
+        $result = $search->search($searchTerm);
+
+        $payload = [
+            'query' => $searchTerm,
+            'clang' => $clang,
+            'limit' => [$limitStart, $limitCount],
+            'result' => $result,
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handlePublicSearch($parameter, array $route = []): Response
+    {
+        try {
+            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+        }
+
+        $searchTerm = trim((string) ($query['q'] ?? ''));
+        if (mb_strlen($searchTerm, 'UTF-8') < 2) {
+            return new Response(json_encode(['error' => 'q must be at least 2 characters']), 400);
+        }
+
+        $clang = (int) ($query['clang'] ?? 0);
+        if ($clang <= 0) {
+            $clang = rex_clang::getCurrentId();
+        }
+
+        $limitStart = max(0, (int) ($query['limit_start'] ?? 0));
+        $limitCount = max(1, min(20, (int) ($query['limit_count'] ?? 10)));
+
+        $search = new \search_it($clang);
+        $search->setLimit([$limitStart, $limitCount]);
+        $result = $search->search($searchTerm);
+
+        $payload = [
+            'query' => $searchTerm,
+            'clang' => $clang,
+            'limit' => [$limitStart, $limitCount],
+            'public' => true,
+            'result' => $result,
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handleReindex($parameter, array $route = []): Response
+    {
+        $data = json_decode((string) rex::getRequest()->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        try {
+            $body = RouteCollection::getQuerySet($data, $parameter['Body']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'Body field: `' . $e->getMessage() . '` is required']), 400);
+        }
+
+        $search = new \search_it();
+        $articleId = (int) ($body['article_id'] ?? 0);
+        $clang = (int) ($body['clang'] ?? -1);
+        $clearCache = (bool) ($body['clear_cache'] ?? true);
+
+        if ($articleId > 0) {
+            $indexResult = $clang >= 0 ? $search->indexArticle($articleId, $clang) : $search->indexArticle($articleId);
+            if ($clearCache) {
+                $search->deleteCache();
+            }
+
+            return new Response(json_encode([
+                'mode' => 'article',
+                'article_id' => $articleId,
+                'clang' => $clang,
+                'result' => $indexResult,
+            ], JSON_PRETTY_PRINT));
+        }
+
+        $warnings = $search->generateIndex();
+
+        return new Response(json_encode([
+            'mode' => 'full',
+            'warnings' => $warnings,
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/lib/search_it.php
+++ b/lib/search_it.php
@@ -255,7 +255,7 @@ class search_it
                 continue;
             }
 
-            if (is_object($article) and ($article->isOnline() or rex_addon::get('search_it')->getConfig('indexoffline')) and $_id != 0
+            if (is_object($article) and ($article->getValue('status') ===1  or rex_addon::get('search_it')->getConfig('indexoffline')) and $_id != 0
                 and ($_id != rex_article::getNotfoundArticleId() or $_id == rex_article::getSiteStartArticleId())) {
 
                 if (!$dont_use_socket) {
@@ -462,7 +462,7 @@ class search_it
         $article = rex_article::get($article_id, $clang_id);
         if (is_null($article)) {
             $return[$clang_id] = SEARCH_IT_ART_IDNOTFOUND;
-        } else if (is_object($article) and ($article->isOnline() or rex_addon::get('search_it')->getConfig('indexoffline'))) {
+        } else if (is_object($article) and ($article->getValue('status') === 1 or rex_addon::get('search_it')->getConfig('indexoffline'))) {
             try {
 
                 $index_host = rex_addon::get('search_it')->getConfig('index_host');

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '6.9.10'
+version: '6.10.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 


### PR DESCRIPTION
## Summary

Dieser PR erweitert `search_it` um API-Endpunkte im Stil des `code`-Addons und dokumentiert die Nutzung.

## Änderungen

- Neue RoutePackages für `search_it`:
  - `lib/Api/RoutePackage/SearchIt.php`
  - `lib/Api/RoutePackage/Backend/SearchIt.php`
- Registrierung der RoutePackages in `boot.php` (nur wenn Addon `api` verfügbar ist)
- Neue Endpunkte:
  - `GET /api/search_it/capabilities` (Bearer)
  - `GET /api/search_it/search` (Bearer)
  - `POST /api/search_it/reindex` (Bearer)
  - `GET /api/search_it/public/search` (öffentlich)
- Backend-Spiegelrouten `backend/search_it/...` via `BackendUser`
- Schutzgrenzen für öffentlichen Zugriff:
  - Suchbegriff mindestens 2 Zeichen
  - `limit_count` max. 20
- Version angehoben auf `6.10.0`
- `CHANGELOG.md` erweitert
- `README.md` um API-Sektion erweitert

## Tests

Lokal gegen `https://localhost:8443` getestet:

- Bearer-Route mit Token: `200 OK`
- Public-Route ohne Token: `200 OK`
- Bearer-Route ohne Token: `401 Unauthorized`
