### PR TITLE
API-Endpunkte für aktuelles search_it (v7.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 7.2.0 (2026-05-30)
+- Neu: API-Endpunkte für das Addon api (`search_it/capabilities`, `search_it/search`, `search_it/reindex`)
+- Neu: Öffentlicher Endpunkt `search_it/public/search` ohne Bearer-Token
+- API-Auth: geschützte Routen via Bearer-Auth, Backend-Spiegelrouten via BackendUser
+- Öffentliche Suche mit Schutzgrenzen (mindestens 2 Zeichen Suchbegriff, `limit_count` max. 20)
+
 ## Version 7.1.6 (2026-03-27)
 - Fix: PlaintextConverter gibt HTML-Entities im Plaintext aus und fehlende Leerzeichen zwischen Block-Elementen thx @iriswerner (#480)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,47 @@ miteinbezogen.
 Nach der Installation sollten zunächst die Einstellungen vorgenommen werden und
 anschließend der Index vollständig generiert werden.
 
+## API-Endpunkte (Addon api)
+
+Wenn das Addon api installiert und aktiv ist, registriert search_it zusätzliche Endpunkte.
+
+### Geschützte Endpunkte (Bearer)
+
+Diese Endpunkte erfordern einen gültigen Bearer-Token:
+
+* GET /api/search_it/capabilities
+* GET /api/search_it/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10
+* POST /api/search_it/reindex
+
+Beispiel:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "https://example.org/api/search_it/search?q=test"
+```
+
+### Öffentlicher Endpunkt (ohne Bearer)
+
+Der folgende Endpunkt ist öffentlich erreichbar:
+
+* GET /api/search_it/public/search?q=<suchbegriff>&clang=1&limit_start=0&limit_count=10
+
+Schutzgrenzen für den öffentlichen Zugriff:
+
+* Suchbegriff muss mindestens 2 Zeichen lang sein
+* limit_count wird auf maximal 20 begrenzt
+
+Beispiel:
+
+```bash
+curl "https://example.org/api/search_it/public/search?q=test"
+```
+
+### Backend-Spiegelrouten
+
+Die search_it-Scopes werden zusätzlich als backend/...-Routen registriert
+und dort über BackendUser abgesichert.
+
 ## Lizenz
 
 [MIT Lizenz](https://github.com/FriendsOfREDAXO/search_it/blob/main/LICENSE)

--- a/boot.php
+++ b/boot.php
@@ -1,5 +1,6 @@
 <?php
 
+use FriendsOfRedaxo\Api\RouteCollection;
 use FriendsOfRedaxo\SearchIt\SearchIt;
 use FriendsOfRedaxo\SearchIt\Cronjob\Reindex;
 use FriendsOfRedaxo\SearchIt\Cronjob\ClearCache;
@@ -46,6 +47,18 @@ if (!defined('SEARCH_IT_ART_EXCLUDED')) {
 
 $curDir = __DIR__;
 require_once $curDir . '/functions/functions_search_it.php';
+
+if (rex_addon::get('api')->isAvailable() && class_exists(RouteCollection::class)) {
+    $apiRoutePackageClass = 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt';
+    if (class_exists($apiRoutePackageClass)) {
+        RouteCollection::registerRoutePackage(new $apiRoutePackageClass());
+    }
+
+    $apiBackendRoutePackageClass = 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\Backend\\SearchIt';
+    if (class_exists($apiBackendRoutePackageClass)) {
+        RouteCollection::registerRoutePackage(new $apiBackendRoutePackageClass());
+    }
+}
 
 if (rex_request('search_highlighter', 'string', '') != '' && rex_addon::get('search_it')->getConfig('highlighterclass') != '') {
     rex_extension::register('OUTPUT_FILTER', Highlighter::outputFilter(...));

--- a/lib/Api/RoutePackage/Backend/SearchIt.php
+++ b/lib/Api/RoutePackage/Backend/SearchIt.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FriendsOfRedaxo\SearchIt\Api\RoutePackage\Backend;
+
+use FriendsOfRedaxo\Api\Auth\BackendUser;
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\SearchIt\Api\RoutePackage\SearchIt as TokenSearchIt;
+
+use function strlen;
+
+class SearchIt extends TokenSearchIt
+{
+    public function loadRoutes()
+    {
+        $routes = RouteCollection::getRoutes();
+
+        foreach ($routes as $route) {
+            if ('search_it/' === substr($route['scope'], 0, strlen('search_it/'))) {
+                $scope = 'backend/' . $route['scope'];
+                $newRoute = clone $route['route'];
+                $newRoute->setPath('backend/' . ltrim($newRoute->getPath(), '/'));
+
+                RouteCollection::registerRoute(
+                    $scope,
+                    $newRoute,
+                    $route['description'],
+                    $route['responses'],
+                    new BackendUser(),
+                    ['backend'],
+                );
+            }
+        }
+    }
+}

--- a/lib/Api/RoutePackage/SearchIt.php
+++ b/lib/Api/RoutePackage/SearchIt.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace FriendsOfRedaxo\SearchIt\Api\RoutePackage;
+
+use Exception;
+use FriendsOfRedaxo\Api\Auth\BearerAuth;
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\Api\RoutePackage;
+use FriendsOfRedaxo\SearchIt\SearchIt as SearchService;
+use rex;
+use rex_addon;
+use rex_clang;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
+
+use const JSON_PRETTY_PRINT;
+
+class SearchIt extends RoutePackage
+{
+    public function loadRoutes()
+    {
+        RouteCollection::registerRoute(
+            'search_it/public/search',
+            new Route(
+                'search_it/public/search',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handlePublicSearch',
+                    'query' => [
+                        'q' => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_start' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_count' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 10,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET'],
+            ),
+            'Execute a public search_it query without bearer token',
+            null,
+            null,
+            ['search_it'],
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/capabilities',
+            new Route(
+                'search_it/capabilities',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleCapabilities',
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET'],
+            ),
+            'Get search_it capabilities and addon configuration snapshot',
+            null,
+            new BearerAuth(),
+            ['search_it'],
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/search',
+            new Route(
+                'search_it/search',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleSearch',
+                    'query' => [
+                        'q' => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_start' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'limit_count' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 10,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['GET'],
+            ),
+            'Execute a search_it fulltext query',
+            null,
+            new BearerAuth(),
+            ['search_it'],
+        );
+
+        RouteCollection::registerRoute(
+            'search_it/reindex',
+            new Route(
+                'search_it/reindex',
+                [
+                    '_controller' => 'FriendsOfRedaxo\\SearchIt\\Api\\RoutePackage\\SearchIt::handleReindex',
+                    'Body' => [
+                        'article_id' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'clang' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => -1,
+                        ],
+                        'clear_cache' => [
+                            'type' => 'bool',
+                            'required' => false,
+                            'default' => true,
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['POST'],
+            ),
+            'Reindex search_it data (full or per article)',
+            null,
+            new BearerAuth(),
+            ['search_it'],
+        );
+    }
+
+    /** @api */
+    public static function handleCapabilities($parameter, array $route = []): Response
+    {
+        $addon = rex_addon::get('search_it');
+
+        $payload = [
+            'addon' => 'search_it',
+            'version' => $addon->getVersion(),
+            'config' => [
+                'searchmode' => $addon->getConfig('searchmode'),
+                'logicalmode' => $addon->getConfig('logicalmode'),
+                'highlight' => $addon->getConfig('highlight'),
+                'limit' => $addon->getConfig('limit'),
+                'indexoffline' => (bool) $addon->getConfig('indexoffline'),
+                'index_url_addon' => (bool) $addon->getConfig('index_url_addon'),
+                'indexmediapool' => (bool) $addon->getConfig('indexmediapool'),
+            ],
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handleSearch($parameter, array $route = []): Response
+    {
+        try {
+            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+        }
+
+        $searchTerm = trim((string) ($query['q'] ?? ''));
+        if ('' === $searchTerm) {
+            return new Response(json_encode(['error' => 'q must not be empty']), 400);
+        }
+
+        $clang = (int) ($query['clang'] ?? 0);
+        if ($clang <= 0) {
+            $clang = rex_clang::getCurrentId();
+        }
+
+        $limitStart = max(0, (int) ($query['limit_start'] ?? 0));
+        $limitCount = max(1, (int) ($query['limit_count'] ?? 10));
+
+        $search = new SearchService($clang);
+        $search->setLimit([$limitStart, $limitCount]);
+        $result = $search->search($searchTerm);
+
+        $payload = [
+            'query' => $searchTerm,
+            'clang' => $clang,
+            'limit' => [$limitStart, $limitCount],
+            'result' => $result,
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handlePublicSearch($parameter, array $route = []): Response
+    {
+        try {
+            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+        }
+
+        $searchTerm = trim((string) ($query['q'] ?? ''));
+        if (mb_strlen($searchTerm, 'UTF-8') < 2) {
+            return new Response(json_encode(['error' => 'q must be at least 2 characters']), 400);
+        }
+
+        $clang = (int) ($query['clang'] ?? 0);
+        if ($clang <= 0) {
+            $clang = rex_clang::getCurrentId();
+        }
+
+        $limitStart = max(0, (int) ($query['limit_start'] ?? 0));
+        $limitCount = max(1, min(20, (int) ($query['limit_count'] ?? 10)));
+
+        $search = new SearchService($clang);
+        $search->setLimit([$limitStart, $limitCount]);
+        $result = $search->search($searchTerm);
+        $publicResult = self::sanitizePublicResult($result);
+
+        $payload = [
+            'query' => $searchTerm,
+            'clang' => $clang,
+            'limit' => [$limitStart, $limitCount],
+            'public' => true,
+            'result' => $publicResult,
+        ];
+
+        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    /** @api */
+    public static function handleReindex($parameter, array $route = []): Response
+    {
+        $data = json_decode((string) rex::getRequest()->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        try {
+            $body = RouteCollection::getQuerySet($data, $parameter['Body']);
+        } catch (Exception $e) {
+            return new Response(json_encode(['error' => 'Body field: `' . $e->getMessage() . '` is required']), 400);
+        }
+
+        $search = new SearchService();
+        $articleId = (int) ($body['article_id'] ?? 0);
+        $clang = (int) ($body['clang'] ?? -1);
+        $clearCache = (bool) ($body['clear_cache'] ?? true);
+
+        if ($clang >= 0 && !rex_clang::exists($clang)) {
+            return new Response(json_encode(['error' => 'Invalid clang id']), 400);
+        }
+
+        if ($articleId > 0) {
+            $indexResult = $clang >= 0 ? $search->indexArticle($articleId, $clang) : $search->indexArticle($articleId);
+            if ($clearCache) {
+                $search->deleteCache();
+            }
+
+            return new Response(json_encode([
+                'mode' => 'article',
+                'article_id' => $articleId,
+                'clang' => $clang,
+                'result' => $indexResult,
+            ], JSON_PRETTY_PRINT));
+        }
+
+        $warnings = $search->generateIndex();
+
+        return new Response(json_encode([
+            'mode' => 'full',
+            'warnings' => $warnings,
+        ], JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     * @return array<string, mixed>
+     */
+    private static function sanitizePublicResult(array $result): array
+    {
+        unset($result['sql'], $result['hash']);
+
+        if (!isset($result['hits']) || !is_array($result['hits'])) {
+            return $result;
+        }
+
+        $allowedHitKeys = [
+            'id',
+            'fid',
+            'catid',
+            'texttype',
+            'clang',
+            'teaser',
+            'filename',
+            'fileext',
+            'RELEVANCE_SEARCH_IT',
+            'COUNT_SEARCH_IT',
+        ];
+
+        foreach ($result['hits'] as $index => $hit) {
+            if (!is_array($hit)) {
+                continue;
+            }
+
+            $result['hits'][$index] = array_intersect_key($hit, array_flip($allowedHitKeys));
+        }
+
+        return $result;
+    }
+}

--- a/lib/Api/RoutePackage/SearchIt.php
+++ b/lib/Api/RoutePackage/SearchIt.php
@@ -174,21 +174,21 @@ class SearchIt extends RoutePackage
             ],
         ];
 
-        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+        return self::jsonResponse($payload);
     }
 
     /** @api */
     public static function handleSearch($parameter, array $route = []): Response
     {
         try {
-            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+            $query = RouteCollection::getQuerySet((array) rex::getRequest()->query->all(), $parameter['query']);
         } catch (Exception $e) {
-            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+            return self::jsonResponse(['error' => 'query field: ' . $e->getMessage() . ' is required'], 400);
         }
 
         $searchTerm = trim((string) ($query['q'] ?? ''));
         if ('' === $searchTerm) {
-            return new Response(json_encode(['error' => 'q must not be empty']), 400);
+            return self::jsonResponse(['error' => 'q must not be empty'], 400);
         }
 
         $clang = (int) ($query['clang'] ?? 0);
@@ -210,21 +210,21 @@ class SearchIt extends RoutePackage
             'result' => $result,
         ];
 
-        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+        return self::jsonResponse($payload);
     }
 
     /** @api */
     public static function handlePublicSearch($parameter, array $route = []): Response
     {
         try {
-            $query = RouteCollection::getQuerySet($_REQUEST, $parameter['query']);
+            $query = RouteCollection::getQuerySet((array) rex::getRequest()->query->all(), $parameter['query']);
         } catch (Exception $e) {
-            return new Response(json_encode(['error' => 'query field: ' . $e->getMessage() . ' is required']), 400);
+            return self::jsonResponse(['error' => 'query field: ' . $e->getMessage() . ' is required'], 400);
         }
 
         $searchTerm = trim((string) ($query['q'] ?? ''));
         if (mb_strlen($searchTerm, 'UTF-8') < 2) {
-            return new Response(json_encode(['error' => 'q must be at least 2 characters']), 400);
+            return self::jsonResponse(['error' => 'q must be at least 2 characters'], 400);
         }
 
         $clang = (int) ($query['clang'] ?? 0);
@@ -248,7 +248,7 @@ class SearchIt extends RoutePackage
             'result' => $publicResult,
         ];
 
-        return new Response(json_encode($payload, JSON_PRETTY_PRINT));
+        return self::jsonResponse($payload);
     }
 
     /** @api */
@@ -262,7 +262,7 @@ class SearchIt extends RoutePackage
         try {
             $body = RouteCollection::getQuerySet($data, $parameter['Body']);
         } catch (Exception $e) {
-            return new Response(json_encode(['error' => 'Body field: `' . $e->getMessage() . '` is required']), 400);
+            return self::jsonResponse(['error' => 'Body field: `' . $e->getMessage() . '` is required'], 400);
         }
 
         $search = new SearchService();
@@ -271,7 +271,11 @@ class SearchIt extends RoutePackage
         $clearCache = (bool) ($body['clear_cache'] ?? true);
 
         if ($clang >= 0 && !rex_clang::exists($clang)) {
-            return new Response(json_encode(['error' => 'Invalid clang id']), 400);
+            return self::jsonResponse(['error' => 'Invalid clang id'], 400);
+        }
+
+        if ($articleId <= 0 && false === $clearCache) {
+            return self::jsonResponse(['error' => 'clear_cache=false is only supported for article reindex'], 400);
         }
 
         if ($articleId > 0) {
@@ -280,20 +284,20 @@ class SearchIt extends RoutePackage
                 $search->deleteCache();
             }
 
-            return new Response(json_encode([
+            return self::jsonResponse([
                 'mode' => 'article',
                 'article_id' => $articleId,
                 'clang' => $clang,
                 'result' => $indexResult,
-            ], JSON_PRETTY_PRINT));
+            ]);
         }
 
         $warnings = $search->generateIndex();
 
-        return new Response(json_encode([
+        return self::jsonResponse([
             'mode' => 'full',
             'warnings' => $warnings,
-        ], JSON_PRETTY_PRINT));
+        ]);
     }
 
     /**
@@ -320,15 +324,28 @@ class SearchIt extends RoutePackage
             'RELEVANCE_SEARCH_IT',
             'COUNT_SEARCH_IT',
         ];
+        $allowedHitKeyMap = array_flip($allowedHitKeys);
 
         foreach ($result['hits'] as $index => $hit) {
             if (!is_array($hit)) {
                 continue;
             }
 
-            $result['hits'][$index] = array_intersect_key($hit, array_flip($allowedHitKeys));
+            $result['hits'][$index] = array_intersect_key($hit, $allowedHitKeyMap);
         }
 
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function jsonResponse(array $payload, int $status = 200): Response
+    {
+        return new Response(
+            json_encode($payload, JSON_PRETTY_PRINT),
+            $status,
+            ['Content-Type' => 'application/json']
+        );
     }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: search_it
-version: '7.1.6'
+version: '7.2.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/search_it
 


### PR DESCRIPTION
## Summary

API-Endpunkte für das Addon api.

## Änderungen

- Neue RoutePackages:
  - lib/Api/RoutePackage/SearchIt.php
  - lib/Api/RoutePackage/Backend/SearchIt.php
- Registrierung in boot.php (nur wenn api verfügbar ist)
- Endpunkte:
  - GET /api/search_it/capabilities (Bearer)
  - GET /api/search_it/search (Bearer)
  - POST /api/search_it/reindex (Bearer)
  - GET /api/search_it/public/search (öffentlich)
- Öffentliche Suche abgesichert:
  - Suchbegriff mindestens 2 Zeichen
  - limit_count auf max. 20 begrenzt
  - interne Felder (sql, hash, rohe Trefferinhalte) werden aus Public-Response entfernt
- Reindex-API validiert clang und gibt bei ungültiger Sprache 400 zurück
- Version auf 7.2.0 erhöht
- CHANGELOG.md und README.md erweitert

## Tests und Ergebnisse (lokal)

Getestet gegen https://localhost:8443 mit Token xxxxxx.

1. GET /api/search_it/capabilities mit Bearer
- Ergebnis: HTTP 200
- Response:
```json
{
  "addon": "search_it",
  "version": "7.2.0"
}
```

2. GET /api/search_it/search?q=test ohne Token
- Ergebnis: HTTP 401
- Response:
```json
{"error":"Authorization failed"}
```

3. GET /api/search_it/public/search?q=test ohne Token
- Ergebnis: HTTP 200
- Response (gekürzt):
```json
{
  "query": "test",
  "public": true,
  "result": {
    "count": 0,
    "hits": []
  }
}
```

4. POST /api/search_it/reindex mit ungültigem clang (Bearer)
- Request-Body:
```json
{"article_id":1,"clang":9999}
```
- Ergebnis: HTTP 400
- Response:
```json
{"error":"Invalid clang id"}
```
